### PR TITLE
Refactor/#008 블록 렌더링 로직 수정

### DIFF
--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -11,6 +11,7 @@ import {
 import { motion } from "framer-motion";
 import { memo, useEffect, useRef, useState } from "react";
 import { useModal } from "@src/components/modal/useModal";
+import { textStyles } from "@src/styles/typography";
 import { getAbsoluteCaretPosition } from "@src/utils/caretUtils";
 import { useBlockAnimation } from "../../hooks/useBlockAnimtaion";
 import { setInnerHTML, getTextOffset } from "../../utils/domSyncUtils";
@@ -106,6 +107,11 @@ export const Block: React.FC<BlockProps> = memo(
           block,
         },
       });
+    const [textStyle, setTextStyle] = useState<string>(
+      block.crdt.LinkedList.spread()
+        .map((char) => char.style)
+        .join(""),
+    );
 
     // 현재 드래그 중인 부모 블록의 indent 확인
     const isChildOfDragging = dragBlockList.some((item) => item === data.id);
@@ -266,11 +272,32 @@ export const Block: React.FC<BlockProps> = memo(
       />
     );
 
+    const getTextAndStylesHash = (block: CRDTBlock) => {
+      const chars = block.crdt.LinkedList.spread();
+      return JSON.stringify(
+        chars.map((char) => ({
+          value: char.value,
+          style: char.style,
+          color: char.color,
+          backgroundColor: char.backgroundColor,
+        })),
+      );
+    };
+
     useEffect(() => {
       if (blockRef.current) {
+        console.log(block.crdt.serialize());
         setInnerHTML({ element: blockRef.current, block });
       }
-    }, [block.crdt.serialize()]);
+    }, [getTextAndStylesHash(block)]);
+
+    // useEffect(() => {
+    //   console.log(block.crdt);
+    //   if (blockRef.current) {
+    //     console.log(block.crdt.LinkedList.spread());
+    //     setInnerHTML({ element: blockRef.current, block });
+    //   }
+    // }, [block.crdt.serialize()]);
 
     return (
       // TODO: eslint 규칙을 수정해야 할까?

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -107,11 +107,6 @@ export const Block: React.FC<BlockProps> = memo(
           block,
         },
       });
-    const [textStyle, setTextStyle] = useState<string>(
-      block.crdt.LinkedList.spread()
-        .map((char) => char.style)
-        .join(""),
-    );
 
     // 현재 드래그 중인 부모 블록의 indent 확인
     const isChildOfDragging = dragBlockList.some((item) => item === data.id);

--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -11,7 +11,6 @@ import {
 import { motion } from "framer-motion";
 import { memo, useEffect, useRef, useState } from "react";
 import { useModal } from "@src/components/modal/useModal";
-import { textStyles } from "@src/styles/typography";
 import { getAbsoluteCaretPosition } from "@src/utils/caretUtils";
 import { useBlockAnimation } from "../../hooks/useBlockAnimtaion";
 import { setInnerHTML, getTextOffset } from "../../utils/domSyncUtils";


### PR DESCRIPTION
## 📝 변경 사항

- 기존 innerHtml 문자열을 직접 변경하는 방식에서 `documentFragment`를 통해 DOM Api를 사용하는 방식으로 수정했습니다.

## 🔍 변경 사항 설명

- setInnerHtml 함수에서 innerhtml text를 생성하는 부분을 documentFragment를 사용하도록 수정
- 텍스트에 스타일이 없는 텍스트 노드를 span으로 감싸던 문제 해결

## 🙏 질문 사항

## 📷 스크린샷 (선택)

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
