### PR TITLE
Refactor/#014 Write Back 캐시 로직을 이벤트 소싱 패턴으로 변경

### DIFF
--- a/@noctaCrdt/src/types/Interfaces.ts
+++ b/@noctaCrdt/src/types/Interfaces.ts
@@ -66,6 +66,23 @@ export type PageIconType =
 
 export type TextColorType = Exclude<BackgroundColorType, "transparent">;
 
+export type CRDTOperation =
+  | RemoteBlockInsertOperation
+  | RemoteBlockDeleteOperation
+  | RemoteBlockUpdateOperation
+  | RemoteBlockReorderOperation
+  | RemoteBlockCheckboxOperation
+  | RemoteCharInsertOperation
+  | RemoteCharDeleteOperation
+  | RemoteCharUpdateOperation;
+
+export type Operation =
+  | RemotePageCreateOperation
+  | RemotePageDeleteOperation
+  | RemotePageUpdateOperation
+  | CRDTOperation
+  | CursorPosition;
+
 export interface InsertOperation {
   type: "insert";
   node: Block | Char;


### PR DESCRIPTION
#014

## 📝 변경 사항

- 클라이언트로부터 받은 연산을 별도 워크스페이스 데이터 캐시에 즉각적으로 반영하는 방식에서, 연산 자체를 저장해두었다가 주기적으로 DB에 반영하는 방식으로 수정

## 🔍 변경 사항 설명

- 워크스페이스 데이터를 Write Back 방식으로 캐싱하고 클라이언트에게 받은 연산을 캐시에 적용한 뒤에 주기적으로 DB에 백업하던 기존 로직에서 이벤트 소싱 패턴을 통해 클라이언트로부터 받은 연산을 그대로 저장한 뒤 주기적으로 DB에 적용하는 방식으로 로직을 수정함
- 기존 방식에서 캐시의 용량이 과도하게 컸는데, 인메모리에서 관리하는 데이터를 워크스페이스 데이터에서 연산 데이터로 변경하면서 인메모리 데이터 용량을 줄임
- 추가로 변경 사항 추적, 복원 등에서도 강점을 가질 것으로 보임
- [개발 위키](https://www.notion.so/Nocta-211f6b8c9c9747fd9fb6a8d8d7d6d8e4)

## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
