### PR TITLE
Feature/#029 리스트 가상화 순서이동 버그

### DIFF
--- a/client/src/features/editor/components/block/Block.tsx
+++ b/client/src/features/editor/components/block/Block.tsx
@@ -288,7 +288,7 @@ export const Block: React.FC<BlockProps> = memo(
       if (blockRef.current) {
         setInnerHTML({ element: blockRef.current, block });
       }
-    }, [getTextAndStylesHash(block)]);
+    }, [virtualIndex, getTextAndStylesHash(block)]);
 
     // useEffect(() => {
     //   console.log(block.crdt);

--- a/client/src/features/editor/utils/domSyncUtils.ts
+++ b/client/src/features/editor/utils/domSyncUtils.ts
@@ -60,9 +60,14 @@ const getClassNames = (state: TextStyleState): string => {
 };
 export const setInnerHTML = ({ element, block }: SetInnerHTMLProps): void => {
   const chars = block.crdt.LinkedList.spread();
+
+  let caretNode: Node | undefined;
+
   const selection = window.getSelection();
-  const range = selection?.getRangeAt(0);
-  let caretNode = range?.startContainer;
+  if (selection && selection.rangeCount > 0) {
+    const range = selection.getRangeAt(0);
+    caretNode = range.startContainer;
+  }
 
   if (chars.length === 0) {
     while (element.firstChild) {


### PR DESCRIPTION
## 📝 변경 사항

- close #029

## 🔍 변경 사항 설명

블록 간 순서를 바꿨을때, 바뀐 내용이 바로 업데이트 되지 않는 문제가 있었습니다.
페이지를 아예 새로 열어야지 화면에 그려졌습니다. (서버에서 연산은 제대로 일어나는 상태)

<img width="465" alt="image" src="https://github.com/user-attachments/assets/5392b404-5096-4552-8b12-02433caf22f0" />

![image](https://github.com/user-attachments/assets/37896c78-db14-42b0-bc2c-84555fc143bf)

맨 처음 페이지를 들어왔을때, a, b 컴포넌트 size는 기본 높이인 24px로 되었다가, 
tanstack virtual 라이브러리에서 계산이 일어나면서 32px, 24px로 계산되어 다시 렌더링이 일어납니다.

여기서 만약 a, b 컴포넌트 위치를 바꾸게 되면, block crdt 내용 자체는 정상적으로 바뀝니다. (그래서 페이지 다시 열면 업데이트 됬던 것)
그렇지만 React상에서 setInnerHTML로 블럭내용이 다시 그려지는 조건은 다음과 같습니다. (블럭 내용이나, 스타일등이 변경되었을 때)
![image](https://github.com/user-attachments/assets/8486e8bc-2bb8-42d0-96d8-30b71ade5007)

로그를 찍어보면 tanstack virtual 에서 사이즈 계산 전후 2번이 찍히는데, block crdt 내용 자체는 변함이 없기에(이미 업데이트 되었기에) tanstack virtual에서 계산이 완료되어도 화면이 업데이트되지 않습니다. (setInnerHTML이 호출되지 않아 그려지지 않음)
![image](https://github.com/user-attachments/assets/f8697b91-2a47-4ea2-b787-27acd18f49e5)

이에 다음과 같이 의존성 배열에 virtual Index(화면에 몇번째로 보여줄지 tanstack virtual에서 제공해주는 값)을 추가해서 setInnerHTML 호출이 되도록 바꿔줬습니다. 
![image](https://github.com/user-attachments/assets/5f54b9c0-7154-4261-90cb-159898fc7b0a)

추가적으로, Block의 key는 clock id과 client id로 이루어져있는데, reorder연산은 해당 id를 변경하지 않기에 Block은 재렌더링되지 않습니다. 게다가 순서가 바뀌더라도 key는 동일하기에, 재렌더링될때도 Block 컴포넌트를 재활용합니다. 그러나 virtualIndex, 즉 화면에 몇번째로 보여줄지는 달라지기에 이를 의존성 배열에 추가해줬습니다.


## 🙏 질문 사항

- [ ] 리뷰어에게 부탁하고싶은 체크리스트를 추가합니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/3c7b63da-ea03-4f1e-9ac8-8003c135c122


## ✅ 작성자 체크리스트

- [ ] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [ ] 로컬에서 모든 기능이 정상 작동함
- [ ] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
