### PR TITLE
Feature/#032 ai 응답 ux 개선

### DIFF
--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -53,6 +53,9 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
           clientId: operation.clientId,
         });
         addPage(newPage);
+        if (operation.clientId === clientId) {
+          setPageDataReady(newPage.id, true);
+        }
       },
       onRemotePageDelete: (operation) => {
         addToast(`${operation.clientId}번 유저가 페이지(${operation.pageTitle})를 삭제하였습니다.`);
@@ -146,7 +149,7 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
         zIndex: getZIndex(),
         isActive: true,
         isVisible: true,
-        isLoaded: true,
+        isLoaded: false,
         serializedEditorData,
       } as Page,
     ]);

--- a/client/src/features/workSpace/hooks/usePagesManage.ts
+++ b/client/src/features/workSpace/hooks/usePagesManage.ts
@@ -146,7 +146,7 @@ export const usePagesManage = (workspace: WorkSpace | null, clientId: number | n
         zIndex: getZIndex(),
         isActive: true,
         isVisible: true,
-        isLoaded: false,
+        isLoaded: true,
         serializedEditorData,
       } as Page,
     ]);

--- a/server/src/ai/ai.controller.ts
+++ b/server/src/ai/ai.controller.ts
@@ -49,13 +49,7 @@ export class AiController {
     @Body() body: { clientId: number; workspaceId: string; message: string },
     @Response({ passthrough: true }) res: ExpressResponse,
   ): Promise<void> {
-    const message = await this.aiService.requestAI(body.message);
-    const operations = await this.aiService.generateDocumentToCRDT(
-      body.workspaceId,
-      body.clientId,
-      message,
-    );
-    this.aiService.emitOperations(body.workspaceId, operations);
+    await this.aiService.requestAI(body.message, body.workspaceId, body.clientId);
     res.status(200).send();
   }
 }

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -483,7 +483,7 @@ export class AiService {
 
     // 블록 타입 판정
     console.log("currentLine:", pageCreator.currentLine);
-    const { type, length, indent } = this.parseBlockType(pageCreator.currentLine);
+    const { type, indent } = this.parseBlockType(pageCreator.currentLine);
     console.log("type:", type);
 
     // 블록 속성 업데이트

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -118,7 +118,7 @@ export class AiService {
 
       // response.data가 스트림인지 확인
       if (typeof response.data.on !== "function") {
-        console.error("response.data가 스트림이 아닙니다:", response.data);
+        // console.error("response.data가 스트림이 아닙니다:", response.data);
         return;
       }
 
@@ -184,7 +184,7 @@ export class AiService {
     clientId: number,
     pageCreator: PageCreator,
   ): Promise<void> {
-    if (event.event === "result") console.log("= 토큰 => ", event.data.message);
+    // if (event.event === "result") console.log("= 토큰 => ", event.data.message);
     if (event.event !== "token") return;
     const token = event.data.message?.content || "";
     // console.log("받은 토큰:", token);
@@ -207,7 +207,7 @@ export class AiService {
       `    ### abcd asdfasdf`
       */
       const char = token[i];
-      console.log("char : " + char);
+      // console.log("char : " + char);
 
       if (!pageCreator.currentBlock) {
         pageCreator.currentBlock = await this.createNewBlock(workspaceId, clientId, pageCreator);
@@ -482,9 +482,9 @@ export class AiService {
     if (!pageCreator.currentBlock || !pageCreator.currentLine.trim()) return;
 
     // 블록 타입 판정
-    console.log("currentLine:", pageCreator.currentLine);
+    // console.log("currentLine:", pageCreator.currentLine);
     const { type, indent } = this.parseBlockType(pageCreator.currentLine);
-    console.log("type:", type);
+    // console.log("type:", type);
 
     // 블록 속성 업데이트
     pageCreator.currentBlock.type = type;
@@ -516,7 +516,7 @@ export class AiService {
     if (operation.type !== "pageCreate") {
       this.workspaceService.storeOperation(workspaceId, operation as CRDTOperation);
     }
-    console.log(operation.type);
+    // console.log(operation.type);
     this.workspaceService
       .getServer()
       .to(workspaceId)

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -5,6 +5,7 @@ import {
   RemoteBlockInsertOperation,
   RemotePageCreateOperation,
   RemoteCharInsertOperation,
+  RemoteCharDeleteOperation,
   CRDTOperation,
   RemoteBlockUpdateOperation,
 } from "@noctaCrdt/types/Interfaces";
@@ -12,10 +13,43 @@ import { Block, Char } from "@noctaCrdt/Node";
 import { EditorCRDT } from "@noctaCrdt/Crdt";
 import { Page } from "@noctaCrdt/Page";
 import { nanoid } from "nanoid";
-import { WorkSpaceService } from "../workspace/workspace.service";
 import { BlockId, CharId } from "@noctaCrdt/NodeId";
 import { HttpService } from "@nestjs/axios";
-import { map, lastValueFrom } from "rxjs";
+import { WorkSpaceService } from "../workspace/workspace.service";
+import { firstValueFrom, lastValueFrom, map } from "rxjs";
+import * as readline from "readline";
+
+interface SSEEvent {
+  id?: string;
+  event?: string;
+  data?: any;
+}
+
+interface PageCreator {
+  currentPage: Page | null;
+  currentBlock: Block | null;
+  lastBlock: Block | null;
+  lastChar: Char | null;
+  blockClock: number;
+  charClock: number;
+  currentLine: string;
+
+  specifiedBlockType: boolean;
+  /*
+  `    ### `
+  공백을 받았을 때 전에 받은게 공백이 아니면 블록 타입 지정 로직 수행
+  예외 : *|~|_
+  specifiedBlocType = true;
+  그 뒤에거는 스타일 문법 변환/바로 쏘기
+  `    ### abcd asdfasdf`
+  */
+
+  // 스타일 상태
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+}
 
 @Injectable()
 export class AiService {
@@ -24,7 +58,7 @@ export class AiService {
     private readonly workspaceService: WorkSpaceService,
   ) {}
 
-  async requestAI(message: string): Promise<any> {
+  async requestAI(message: string, workspaceId: string, clientId: number): Promise<void> {
     const payload = {
       messages: [
         {
@@ -38,7 +72,7 @@ export class AiService {
       ],
       topP: 0.8,
       topK: 0,
-      maxTokens: 512,
+      maxTokens: 100,
       temperature: 0.5,
       repeatPenalty: 5.0,
       stopBefore: [],
@@ -46,198 +80,400 @@ export class AiService {
       seed: 0,
     };
 
-    const response$ = this.axiosHttpService
-      .post(process.env.CLOVASTUDIO_API_URL, payload, {
-        headers: {
-          "X-NCP-CLOVASTUDIO-REQUEST-ID": process.env.CLOVASTUDIO_REQUEST_ID, // 요청 ID
-          Authorization: `Bearer ${process.env.CLOVASTUDIO_API_KEY}`, // API 키
-          "Content-Type": "application/json",
-          Accept: "text/event-stream",
+    try {
+      // Axios가 응답을 스트림으로 반환하도록 설정합니다.
+      const response = await this.axiosHttpService.axiosRef.post(
+        process.env.CLOVASTUDIO_API_URL,
+        payload,
+        {
+          headers: {
+            "X-NCP-CLOVASTUDIO-REQUEST-ID": process.env.CLOVASTUDIO_REQUEST_ID,
+            Authorization: `Bearer ${process.env.CLOVASTUDIO_API_KEY}`,
+            "Content-Type": "application/json",
+            Accept: "text/event-stream",
+          },
+          responseType: "stream",
         },
-      })
-      .pipe(
-        map((res) => {
-          return res.data;
-        }),
       );
 
-    const response = await lastValueFrom(response$);
-    const completionText = this.parseClovaSSEBackward(response);
+      // response.data가 스트림인지 확인
+      if (typeof response.data.on !== "function") {
+        console.error("response.data가 스트림이 아닙니다:", response.data);
+        return;
+      }
 
-    return completionText;
-  }
+      // readline 인터페이스를 사용하여 스트림을 한 줄씩 읽습니다.
+      const rl = readline.createInterface({
+        input: response.data,
+        crlfDelay: Infinity,
+      });
 
-  parseClovaSSEBackward(sseText: string): string {
-    const lines = sseText.split("\n").map((line) => line.trim());
+      let eventBuffer: SSEEvent = {};
+      let pageCreator: PageCreator = {
+        currentPage: null,
+        currentBlock: null,
+        lastBlock: null,
+        blockClock: 0,
+        charClock: 0,
+        currentLine: "",
+        lastChar: null,
+        bold: false,
+        italic: false,
+        underline: false,
+        strikethrough: false,
+        specifiedBlockType: false,
+      };
 
-    // 뒤에서부터 역순으로 순회
-    for (let i = lines.length - 1; i >= 0; i--) {
-      // event:result 라인 확인
-      if (lines[i].startsWith("event:result")) {
-        // 다음 줄(혹은 같은 블록 안의 다음 줄)이 data:... 형태일 것
-        const dataLine = lines[i + 1]; // i+1이 안전하게 존재하는지 체크
-        if (dataLine?.startsWith("data:")) {
-          const jsonStr = dataLine.replace(/^data:/, "").trim();
+      // 페이지 초기화
+      pageCreator.currentPage = await this.createNewPage(clientId, "AI 응답", workspaceId);
+
+      rl.on("line", (line: string) => {
+        // 공백 라인이 나오면 이벤트 구분자로 판단하고, 지금까지 버퍼에 담긴 이벤트를 처리합니다.
+        if (!line.trim()) {
+          if (Object.keys(eventBuffer).length > 0) {
+            this.handleSSEEvent(eventBuffer, workspaceId, clientId, pageCreator);
+            eventBuffer = {};
+          }
+          return;
+        }
+
+        // 새로운 이벤트 시작: 이전 이벤트가 있으면 먼저 처리
+        if (line.startsWith("id:")) {
+          // 만약 이미 버퍼에 이벤트 내용이 있다면 flush 합니다.
+          if (eventBuffer.id || eventBuffer.event || eventBuffer.data) {
+            this.handleSSEEvent(eventBuffer, workspaceId, clientId, pageCreator);
+            eventBuffer = {};
+          }
+          eventBuffer.id = line.slice(3).trim();
+        } else if (line.startsWith("event:")) {
+          eventBuffer.event = line.slice(6).trim();
+        } else if (line.startsWith("data:")) {
+          const dataText = line.slice(5).trim();
           try {
-            const parsed = JSON.parse(jsonStr);
-            return parsed?.message?.content ?? "";
-          } catch (err) {
-            console.error("JSON 파싱 실패:", err);
+            eventBuffer.data = JSON.parse(dataText);
+          } catch (error) {
+            // JSON 파싱이 실패하면 그냥 문자열로 저장합니다.
+            eventBuffer.data = dataText;
           }
         }
-        // 만약 i+1줄에 data가 없다면, 더 위로 가봤자 의미 없으니 여기서 끝냄
-        return "";
-      }
-    }
+      });
 
-    return "";
+      rl.on("close", () => {
+        // 스트림 종료 시, 버퍼에 남은 이벤트가 있으면 처리합니다.
+        if (Object.keys(eventBuffer).length > 0) {
+          this.handleSSEEvent(eventBuffer, workspaceId, clientId, pageCreator);
+        }
+        console.log("SSE 스트림이 종료되었습니다.");
+      });
+
+      // 에러 처리도 추가할 수 있습니다.
+      response.data.on("error", (err: Error) => {
+        console.error("스트림 에러 발생:", err);
+      });
+    } catch (error) {
+      console.error("Streaming error:", error);
+    }
   }
 
-  // 요청받은 답변을 CRDT 연산으로 변환하는 로직
-  async generateDocumentToCRDT(
+  async handleSSEEvent(
+    event: SSEEvent,
     workspaceId: string,
     clientId: number,
-    document: string,
-  ): Promise<Operation[]> {
-    const documentLines = document.split("\n");
+    pageCreator: PageCreator,
+  ): Promise<void> {
+    console.log("받은 이벤트:", event);
+    if (event.event !== "token") return;
+    const token = event.data.message?.content || "";
+    await this.processToken(token, workspaceId, clientId, pageCreator);
+  }
 
-    // 페이지 제목 결정
-    let title = documentLines.at(0);
-    const { type, length, indent } = this.parseBlockType(title);
-    title = title.slice(length + indent * 2);
+  private async processToken(
+    token: string,
+    workspaceId: string,
+    clientId: number,
+    pageCreator: PageCreator,
+  ) {
+    for (let i = 0; i < token.length; i++) {
+      /*
+      `    ### `
+      공백을 받았을 때 전에 받은게 공백이 아니면 블록 타입 지정 로직 수행
+      예외 : *|~|_
+      specifiedBlocType = true;
+      그 뒤에거는 스타일 문법 변환/바로 쏘기
+      `    ### abcd asdfasdf`
+      */
+      const char = token[i];
 
-    const operations = [];
+      if (!pageCreator.currentBlock) {
+        pageCreator.currentBlock = await this.createNewBlock(workspaceId, clientId, pageCreator);
+        pageCreator.specifiedBlockType = false;
+      }
 
-    // 새 페이지 생성 후 페이지 생성 연산 추가
+      if (!pageCreator.specifiedBlockType) {
+        pageCreator.currentLine += char;
+        if (char === " " && pageCreator.currentLine.at(-1) !== " ") {
+          await this.updateCurrentBlock(workspaceId, clientId, pageCreator);
+          if (pageCreator.currentBlock.type === "p") {
+            // currentLine에서 indent만큼 공백 지우고
+            // 남은 것들에 대해서
+            // 스타일 문법이면 변환해서 스타일 적용
+            // 아니면 insertChar
+          }
+          pageCreator.specifiedBlockType = true;
+        }
+        continue;
+      }
+
+      if (char === "\n") {
+        // 새 블록 준비
+        pageCreator.currentLine = "";
+        pageCreator.lastChar = null;
+        pageCreator.currentBlock = null;
+        pageCreator.charClock = 0;
+        pageCreator.bold = false;
+        pageCreator.italic = false;
+        pageCreator.underline = false;
+        pageCreator.strikethrough = false;
+        pageCreator.specifiedBlockType = false;
+      }
+
+      // 스타일 문법이면 변환해서 스타일 적용
+      // 아니면 insertChar
+
+      if (char === "*") {
+        if (pageCreator.currentLine === "*") {
+          pageCreator.bold = !pageCreator.bold;
+          i += 1;
+          continue;
+        } else {
+          pageCreator.italic = pageCreator.italic;
+          continue;
+        }
+      } else if (char === "~") {
+        if (pageCreator.currentLine === "~") {
+          pageCreator.strikethrough = !pageCreator.strikethrough;
+          i += 1;
+          continue;
+        } else {
+          if (pageCreator.currentLine !== "") {
+            this.createNewChar(pageCreator.currentLine, workspaceId, clientId, pageCreator);
+            pageCreator.currentLine = "";
+          }
+          pageCreator.currentLine = char;
+        }
+      } else if (char === "_") {
+        if (pageCreator.currentLine === "_") {
+          pageCreator.underline = pageCreator.underline;
+          i += 1;
+          continue;
+        } else {
+          if (pageCreator.currentLine !== "") {
+            this.createNewChar(pageCreator.currentLine, workspaceId, clientId, pageCreator);
+            pageCreator.currentLine = "";
+          }
+          pageCreator.currentLine = char;
+        }
+      }
+
+      /*
+      if (char === "\n" && this.currentBlock) {
+        // 현재 블록 마무리
+        await this.updateCurrentBlock(workspaceId, clientId);
+
+        // 새 블록 준비
+        this.currentLine = "";
+        this.lastChar = null;
+        this.currentBlock = null;
+        this.charClock = 0;
+        this.blockClock = 0;
+
+        this.bold = false;
+        this.italic = false;
+        this.underline = false;
+        this.strikethrough = false;
+        continue;
+      }
+
+      // 현재 라인에 문자 추가 (마크다운 문법 파싱용)
+      this.currentLine += char;
+
+      if (char === "*") {
+        if (i < token.length - 1 && token[i + 1] === "*") {
+          this.bold = !this.bold;
+          i += 1;
+          continue;
+        } else {
+          this.italic = !this.italic;
+          continue;
+        }
+      } else if (char === "~") {
+        if (i < token.length - 1 && token[i + 1] === "~") {
+          this.strikethrough = !this.strikethrough;
+          i += 1;
+          continue;
+        }
+      } else if (char === "_") {
+        if (i < token.length - 1 && token[i + 1] === "_") {
+          this.underline = !this.underline;
+          i += 1;
+          continue;
+        }
+      }
+
+      // 필요한 경우 새 블록 생성
+      if (!this.currentBlock) {
+        await this.createNewBlock(workspaceId, clientId);
+      }
+
+      // 실제 컨텐츠 추가
+      await this.createNewChar(char, workspaceId, clientId);
+      */
+    }
+  }
+
+  private async createNewPage(clientId: number, title: string, workspaceId: string): Promise<Page> {
     const newEditorCRDT = new EditorCRDT(clientId);
-    const newPage = new Page(nanoid(), title, "Docs", newEditorCRDT);
+    const page = new Page(nanoid(), title, "Docs", newEditorCRDT);
 
-    operations.push({
+    const pageOperation = {
       type: "pageCreate",
       workspaceId,
       clientId,
-      page: newPage.serialize(),
-    } as RemotePageCreateOperation);
-
-    // 블록 생성 연산 추가
-    let blockClock = 0;
-    let lastBlock = null;
-
-    documentLines.forEach((line) => {
-      const { type, length, indent } = this.parseBlockType(line);
-
-      const newBlock = new Block("", new BlockId(blockClock, clientId));
-      blockClock += 1;
-      newBlock.next = null;
-      newBlock.prev = lastBlock ? lastBlock.id : null;
-      newBlock.type = type;
-      newBlock.indent = indent;
-      newBlock.animation = type === "h1" ? "rainbow" : type === "h2" ? "highlight" : "none";
-
-      if (lastBlock) {
-        lastBlock.next = newBlock.id;
-      }
-      lastBlock = newBlock;
-
-      operations.push({
-        type: "blockInsert",
-        node: newBlock,
-        pageId: newPage.id,
-      } as RemoteBlockInsertOperation);
-
-      operations.push({
-        type: "blockUpdate",
-        node: newBlock,
-        pageId: newPage.id,
-      } as RemoteBlockUpdateOperation);
-
-      // 문자 생성 연산 추가
-      const slicedLine = [...line.slice(length + indent * 2)];
-      let lastNode = null;
-
-      let charClock = 0;
-
-      let bold = false;
-      let italic = false;
-      let underline = false;
-      let strikethrough = false;
-
-      for (let i = 0; i < slicedLine.length; ++i) {
-        const char = slicedLine[i];
-
-        if (char === "*") {
-          if (i < slicedLine.length - 1 && slicedLine[i + 1] === "*") {
-            bold = !bold;
-            i += 1;
-            continue;
-          } else {
-            italic = !italic;
-            continue;
-          }
-        } else if (char === "~") {
-          if (i < slicedLine.length - 1 && slicedLine[i + 1] === "~") {
-            strikethrough = !strikethrough;
-            i += 1;
-            continue;
-          }
-        } else if (char === "_") {
-          if (i < slicedLine.length - 1 && slicedLine[i + 1] === "_") {
-            underline = !underline;
-            i += 1;
-            continue;
-          }
-        }
-
-        const charNode = new Char(char, new CharId(charClock, clientId));
-        charClock += 1;
-        charNode.next = null;
-        charNode.prev = lastNode ? lastNode.id : null;
-
-        if (lastNode) {
-          lastNode.next = charNode.id;
-        }
-
-        lastNode = charNode;
-
-        const styles = [];
-        if (bold) styles.push("bold");
-        if (italic) styles.push("italic");
-        if (underline) styles.push("underline");
-        if (strikethrough) styles.push("strikethrough");
-
-        operations.push({
-          type: "charInsert",
-          node: charNode,
-          blockId: newBlock.id,
-          pageId: newPage.id,
-          style: styles,
-          color: charNode.color ? charNode.color : "black",
-          backgroundColor: charNode.backgroundColor ? charNode.backgroundColor : "transparent",
-        } as RemoteCharInsertOperation);
-      }
-    });
-
-    return operations;
-  }
-
-  // CRDT 연산들을 페이지에 적용하고 다른 클라이언트에 브로드캐스트
-  async emitOperations(workspaceId: string, operations: Operation[]) {
-    const pageOperation = operations.at(0) as RemotePageCreateOperation;
-    const crdtOperations = operations.slice(1);
+      page: page.serialize(),
+    } as RemotePageCreateOperation;
 
     const workspace = await this.workspaceService.getWorkspace(workspaceId);
     workspace.pageList.push(pageOperation.page);
-    await this.workspaceService.updateWorkspace(workspace);
-    this.workspaceService.getServer().to(workspaceId).emit("create/page", pageOperation);
-
-    crdtOperations.forEach((operation) => {
-      this.workspaceService.storeOperation(workspaceId, operation as CRDTOperation);
-    });
-
-    this.workspaceService.getServer().to(workspaceId).emit("batch/operations", crdtOperations);
+    this.workspaceService.updateWorkspace(workspace);
+    await this.emitOperation(workspaceId, pageOperation);
+    return page;
   }
 
-  // 블록 타입을 판정하는 로직
+  private async createNewBlock(
+    workspaceId: string,
+    clientId: number,
+    pageCreator: PageCreator,
+  ): Promise<Block> {
+    const newBlock = new Block("", new BlockId(pageCreator.blockClock++, clientId));
+    newBlock.next = null;
+    newBlock.prev = pageCreator.lastBlock ? pageCreator.lastBlock.id : null;
+
+    if (pageCreator.lastBlock) {
+      pageCreator.lastBlock.next = newBlock.id;
+    }
+
+    pageCreator.lastBlock = newBlock;
+    pageCreator.currentBlock = newBlock;
+
+    // 블록 삽입 연산 전송
+    const blockInsertOperation: RemoteBlockInsertOperation = {
+      type: "blockInsert",
+      node: newBlock,
+      pageId: pageCreator.currentPage.id,
+    };
+
+    await this.emitOperation(workspaceId, blockInsertOperation);
+    return newBlock;
+  }
+
+  private async createNewChar(
+    char: string,
+    workspaceId: string,
+    clientId: number,
+    pageCreator: PageCreator,
+  ) {
+    const charNode = new Char(char, new CharId(pageCreator.charClock++, clientId));
+    charNode.next = null;
+    charNode.prev = pageCreator.lastChar ? pageCreator.lastChar.id : null;
+
+    if (pageCreator.lastChar) {
+      pageCreator.lastChar.next = charNode.id;
+    }
+
+    pageCreator.lastChar = charNode;
+
+    // 현재 활성화된 스타일 수집
+    const styles = [];
+    if (pageCreator.bold) styles.push("bold");
+    if (pageCreator.italic) styles.push("italic");
+    if (pageCreator.underline) styles.push("underline");
+    if (pageCreator.strikethrough) styles.push("strikethrough");
+
+    // 문자 삽입 연산 전송
+    const charOperation: RemoteCharInsertOperation = {
+      type: "charInsert",
+      node: charNode,
+      blockId: pageCreator.currentBlock.id,
+      pageId: pageCreator.currentPage.id,
+      style: styles,
+      color: "black",
+      backgroundColor: "transparent",
+    };
+
+    await this.emitOperation(workspaceId, charOperation);
+  }
+
+  private async updateCurrentBlock(
+    workspaceId: string,
+    clientId: number,
+    pageCreator: PageCreator,
+  ) {
+    if (!pageCreator.currentBlock || !pageCreator.currentLine.trim()) return;
+
+    // 블록 타입 판정
+    const { type, length, indent } = this.parseBlockType(pageCreator.currentLine);
+
+    // 블록 속성 업데이트
+    pageCreator.currentBlock.type = type;
+    pageCreator.currentBlock.indent = indent;
+    pageCreator.currentBlock.animation = this.determineAnimation(type);
+
+    // 블록 업데이트 연산 전송
+    const blockUpdateOperation: RemoteBlockUpdateOperation = {
+      type: "blockUpdate",
+      node: pageCreator.currentBlock,
+      pageId: pageCreator.currentPage.id,
+    };
+
+    await this.emitOperation(workspaceId, blockUpdateOperation);
+  }
+
+  private determineAnimation(type: ElementType): "rainbow" | "highlight" | "none" {
+    switch (type) {
+      case "h1":
+        return "rainbow";
+      case "h2":
+        return "highlight";
+      default:
+        return "none";
+    }
+  }
+
+  private async emitOperation(workspaceId: string, operation: Operation) {
+    if (operation.type !== "pageCreate") {
+      this.workspaceService.storeOperation(workspaceId, operation as CRDTOperation);
+    }
+    this.workspaceService
+      .getServer()
+      .to(workspaceId)
+      .emit(this.getEventName(operation.type), operation);
+  }
+
+  private getEventName(operationType: string): string {
+    switch (operationType) {
+      case "pageCreate":
+        return "create/page";
+      case "blockInsert":
+        return "insert/block";
+      case "blockUpdate":
+        return "update/block";
+      case "charInsert":
+        return "insert/char";
+      default:
+        return "batch/operations";
+    }
+  }
+
   parseBlockType(line: string): { type: ElementType; length: number; indent: number } {
     const indent = line.match(/^[\s]*/)[0].length / 2 || 0;
     const trimmed = line.trim();

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -83,7 +83,7 @@ export class AiService {
 
     try {
       let eventBuffer: SSEEvent = {};
-      let pageCreator: PageCreator = {
+      const pageCreator: PageCreator = {
         currentPage: null,
         currentBlock: null,
         lastBlock: null,
@@ -389,7 +389,8 @@ export class AiService {
     clientId: number,
     pageCreator: PageCreator,
   ): Promise<Block> {
-    const newBlock = new Block("", new BlockId(pageCreator.blockClock++, clientId));
+    const newBlock = new Block("", new BlockId(pageCreator.blockClock, clientId));
+    pageCreator.blockClock += 1;
     newBlock.next = null;
     newBlock.prev = pageCreator.lastBlock ? pageCreator.lastBlock.id : null;
 
@@ -417,7 +418,8 @@ export class AiService {
     clientId: number,
     pageCreator: PageCreator,
   ): Promise<Char> {
-    const charNode = new Char(char, new CharId(pageCreator.charClock++, clientId));
+    const charNode = new Char(char, new CharId(pageCreator.charClock, clientId));
+    pageCreator.charClock += 1;
     charNode.next = null;
     charNode.prev = pageCreator.lastChar ? pageCreator.lastChar.id : null;
 

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -73,7 +73,7 @@ export class AiService {
       ],
       topP: 0.8,
       topK: 0,
-      maxTokens: 300,
+      maxTokens: 1024,
       temperature: 0.5,
       repeatPenalty: 5.0,
       stopBefore: [],

--- a/server/src/workspace/workspace.service.ts
+++ b/server/src/workspace/workspace.service.ts
@@ -329,10 +329,10 @@ export class WorkSpaceService implements OnModuleInit {
           );
           break;
         default:
-          this.logger.warn("연산 처리 중 알 수 없는 연산 발견:", operation);
+        // this.logger.warn("연산 처리 중 알 수 없는 연산 발견:", operation);
       }
     } catch (error) {
-      this.logger.warn("유효하지 않은 연산:", operation);
+      // this.logger.warn("유효하지 않은 연산:");
     }
   }
 


### PR DESCRIPTION
## 📝 변경 사항

- ai 응답 토큰별로 받아오는 기능 추가하여 UX 개선

## 🔍 변경 사항 설명

- ai 응답 파싱 토큰 단위로 받도록 수정 (기존에는 다 만들어진 마지막 문자열만 받아 처리)
  - ai 토큰 들어올때마다 char, block 단위로 사용자에게 socket 연산 전송
- block 타입 결정 로직 수정
  - 기존에는 완성된 문자열("# 제목")을 보고(아직 사용자에게 보여지지 않음) block 타입을 먼저 결정하고 char 연산을 보내줬음
  - 바뀐 로직은 문자가 들어오는 시점(사용자에게 바로 보여줌)에 바로 전환되도록 수정
- 텍스트 스타일(굵기, 밑줄, 취소선, 기울기) 기능 추가
- 자신이 만든 ai 페이지만 바로 보여주는 기능 추가

## 🙏 질문 사항

- [ ] 잘 동작하는지 확인 부탁드립니다!

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/95876c09-b6df-4020-97c7-cd1ea01b093d


## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
