### PR TITLE
Feature/온보딩 및 페이지 ux 개선

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@lottiefiles/react-lottie-player": "^3.5.4",
     "@noctaCrdt": "workspace:*",
     "@pandabox/panda-plugins": "^0.0.8",
+    "@radix-ui/react-tooltip": "^1.2.4",
     "@tanstack/react-query": "^5.60.5",
     "@tanstack/react-virtual": "^3.11.2",
     "axios": "^1.7.7",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,8 +3,8 @@ import { ErrorModal } from "@components/modal/ErrorModal";
 import { WorkSpace } from "@features/workSpace/WorkSpace";
 import { useErrorStore } from "@stores/useErrorStore";
 import { useUserInfo } from "@stores/useUserStore";
-import { useSocketStore } from "./stores/useSocketStore";
 import { BackgroundImage } from "./components/backgroundImage/BackgroundImage";
+import { useSocketStore } from "./stores/useSocketStore";
 
 const App = () => {
   // TODO 라우터, react query 설정
@@ -13,7 +13,7 @@ const App = () => {
 
   useEffect(() => {
     const socketStore = useSocketStore.getState();
-    const savedWorkspace = sessionStorage.getItem("currentWorkspace");
+    const savedWorkspace = localStorage.getItem("currentWorkspace");
     const workspaceId = savedWorkspace ? JSON.parse(savedWorkspace).id : null;
     socketStore.init(userId, workspaceId);
 

--- a/client/src/components/bottomNavigator/BottomNavigator.tsx
+++ b/client/src/components/bottomNavigator/BottomNavigator.tsx
@@ -1,4 +1,6 @@
+import { Provider, Root, Trigger, Portal, Content, Arrow } from "@radix-ui/react-tooltip";
 import { motion } from "framer-motion";
+import { useState } from "react";
 import { IconButton } from "@components/button/IconButton";
 import { Page } from "@src/types/page";
 import { animation } from "./BottomNavigator.animation";
@@ -15,29 +17,54 @@ export const BottomNavigator = ({
   handlePageSelect,
   BottomNavigatorOnBoardingProps,
 }: BottomNavigatorProps) => {
+  const [zIndex, setZIndex] = useState(1);
   return (
-    <div className={bottomNavigatorContainer} {...BottomNavigatorOnBoardingProps}>
-      {pages.map((page, idx) => (
-        <motion.div
-          key={page.id}
-          initial={animation.initial}
-          animate={animation.animate(page.isActive)}
-          transition={animation.transition}
-          whileHover={animation.whileHover}
-        >
-          <IconButton
-            key={page.id}
-            icon={page.icon}
-            size="md"
-            testKey={`BottomNavigator-iconButton-${idx}`}
-            onClick={() => {
-              handlePageSelect({
-                pageId: page.id,
-              });
-            }}
-          />
-        </motion.div>
-      ))}
-    </div>
+    <Provider delayDuration={300}>
+      <div
+        className={bottomNavigatorContainer}
+        style={{ zIndex }}
+        onMouseEnter={() => setZIndex(100)}
+        onMouseLeave={() => setZIndex(1)}
+        {...BottomNavigatorOnBoardingProps}
+      >
+        {pages.map((page, idx) => (
+          <Root key={page.id}>
+            <Trigger asChild>
+              <motion.div
+                initial={animation.initial}
+                animate={animation.animate(page.isActive)}
+                transition={animation.transition}
+                whileHover={animation.whileHover}
+              >
+                <IconButton
+                  icon={page.icon}
+                  size="md"
+                  testKey={`BottomNavigator-iconButton-${idx}`}
+                  onClick={() => {
+                    handlePageSelect({ pageId: page.id });
+                  }}
+                />
+              </motion.div>
+            </Trigger>
+            <Portal>
+              <Content side="top" sideOffset={16} style={{ zIndex: 9999 }}>
+                <div
+                  style={{
+                    padding: "4px 8px",
+                    background: "#2B4158",
+                    opacity: 0.7,
+                    color: "white",
+                    borderRadius: 4,
+                  }}
+                >
+                  {page.title || "제목 없음"}
+                </div>
+                <Arrow fill="#2B4158" opacity={0.7} />
+              </Content>
+            </Portal>
+          </Root>
+        ))}
+      </div>
+    </Provider>
   );
 };

--- a/client/src/components/sidebar/Sidebar.tsx
+++ b/client/src/components/sidebar/Sidebar.tsx
@@ -84,6 +84,7 @@ export const Sidebar = ({
 
   return (
     <motion.aside
+      data-sidebar
       data-testid="sidebar"
       className={sidebarContainer}
       initial="open"

--- a/client/src/features/editor/components/IconBlock/IconBlock.style.ts
+++ b/client/src/features/editor/components/IconBlock/IconBlock.style.ts
@@ -29,6 +29,7 @@ export const iconStyle = cva({
         borderRadius: "2px",
         width: "16px",
         height: "16px",
+        margin: "auto",
         backgroundColor: "white",
       },
     },

--- a/client/src/features/page/hooks/usePage.ts
+++ b/client/src/features/page/hooks/usePage.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { PAGE, SIDE_BAR } from "@constants/size";
 import { SPACING } from "@constants/spacing";
-import { Position, Size, Direction } from "@src/types/page";
+import { useSnapTargetStore } from "@src/stores/useSnapStore";
+import { Position, Size, Direction, SnapTarget } from "@src/types/page";
 import { useIsSidebarOpen } from "@stores/useSidebarStore";
 
 const PADDING = SPACING.MEDIUM * 2;
-const SNAP_THRESHOLD = 24; // 스냅을 위한 임계값
+const SNAP_THRESHOLD = 12; // 스냅을 위한 임계값
+const DRAG_THRESHOLD = 12; // 드래그를 위한 임계값
 
 // 만약 maximize 상태면, 화면이 커질때도 꽉 촤게 해줘야함.
 export const usePage = ({ x, y }: Position) => {
@@ -21,7 +23,9 @@ export const usePage = ({ x, y }: Position) => {
   });
 
   const [isMaximized, setIsMaximized] = useState(false);
+  const [isSnapped, setIsSnapped] = useState(false);
   const isSidebarOpen = useIsSidebarOpen();
+  const { setTarget, reset } = useSnapTargetStore();
 
   const getSidebarWidth = () => (isSidebarOpen ? SIDE_BAR.WIDTH : SIDE_BAR.MIN_WIDTH);
 
@@ -39,17 +43,16 @@ export const usePage = ({ x, y }: Position) => {
     const height = window.innerHeight;
 
     // Y 영역 퍼센트 기반 구간
-    const topLimit = height * 0.05; // 상단 5%
-    const middleEnd = height * 0.5; // 중간 끝: 50%
-    const bottomStart = middleEnd; // 하단 시작
+    const topLimit = height * 0.05;
+    const bottomLimit = height * 0.9;
 
     const isTop = y < topLimit;
-    const isMiddle = y >= topLimit && y < middleEnd;
-    const isBottom = y >= bottomStart;
+    const isMiddle = y > topLimit && y < bottomLimit;
+    const isBottom = y >= bottomLimit;
 
     // X 영역 좌우 끝 임계값
     const isLeftEdge = x <= SNAP_THRESHOLD + sidebarWidth;
-    const isRightEdge = x >= width - SNAP_THRESHOLD;
+    const isRightEdge = x >= width - SNAP_THRESHOLD * 2;
 
     if (isLeftEdge && isTop) return "topLeft";
     if (isRightEdge && isTop) return "topRight";
@@ -61,55 +64,70 @@ export const usePage = ({ x, y }: Position) => {
     return null;
   };
 
+  const getSnapStyle = (
+    target: SnapTarget,
+    availableWidth: number,
+    fullHeight: number,
+  ): React.CSSProperties => {
+    const width = availableWidth / 2 - PADDING * 0.75;
+    const height = fullHeight / 2 - PADDING * 0.25;
+
+    const common = {
+      width,
+      height,
+    };
+
+    const positions: Record<Exclude<SnapTarget, null>, React.CSSProperties> = {
+      left: { top: 0, left: 0, width, height: fullHeight },
+      right: { top: 0, left: width + PADDING / 2, width, height: fullHeight },
+
+      topLeft: { top: 0, left: 0, ...common },
+      topRight: { top: 0, left: width + PADDING / 2, ...common },
+
+      bottomLeft: { top: height + PADDING * 0.5, left: 0, ...common },
+      bottomRight: { top: height + PADDING * 0.5, left: width + PADDING / 2, ...common },
+    };
+
+    return target ? positions[target] : {};
+  };
+
   const applySnap = (
-    target: ReturnType<typeof computeSnapTarget>,
+    target: SnapTarget,
     _sidebarWidth: number,
     availableWidth: number,
     fullHeight: number,
   ) => {
-    const halfWidth = availableWidth / 2;
-    const halfHeight = fullHeight / 2;
-    const leftX = 0;
-    const rightX = halfWidth - PADDING;
+    const width = availableWidth / 2 - PADDING * 0.75;
+    const height = fullHeight / 2 - PADDING * 0.25;
 
     const base = {
-      width: halfWidth,
-      isMaximized: false,
-    };
+      left: { x: 0, width },
+      right: { x: width + PADDING * 0.5, width },
+    } as const;
 
-    const apply = (x: number, y: number, height: number) => {
-      setPrevPosition(position);
-      setPrevSize(size);
+    const apply = (x: number, y: number, w: number, h: number) => {
+      if (!isSnapped) {
+        setPrevPosition(position);
+        setPrevSize(size);
+      }
       setPosition({ x, y });
-      setSize({ ...base, height });
+      setSize({ width: w, height: h });
       setIsMaximized(false);
+      setIsSnapped(true);
     };
 
-    switch (target) {
-      case "left":
-        apply(leftX, 0, fullHeight);
-        break;
+    const snapMap = {
+      left: () => apply(base.left.x, 0, base.left.width, fullHeight),
+      right: () => apply(base.right.x, 0, base.right.width, fullHeight),
 
-      case "right":
-        apply(rightX, 0, fullHeight);
-        break;
+      topLeft: () => apply(base.left.x, 0, base.left.width, height),
+      topRight: () => apply(base.right.x, 0, base.right.width, height),
 
-      case "topLeft":
-        apply(leftX, 0, halfHeight);
-        break;
+      bottomLeft: () => apply(base.left.x, height + PADDING * 0.5, base.left.width, height),
+      bottomRight: () => apply(base.right.x, height + PADDING * 0.5, base.right.width, height),
+    };
 
-      case "topRight":
-        apply(rightX, 0, halfHeight);
-        break;
-
-      case "bottomLeft":
-        apply(leftX, halfHeight, halfHeight);
-        break;
-
-      case "bottomRight":
-        apply(rightX, halfHeight, halfHeight);
-        break;
-    }
+    snapMap[target]?.();
   };
 
   const pageDrag = (e: React.PointerEvent) => {
@@ -118,17 +136,52 @@ export const usePage = ({ x, y }: Position) => {
     const startY = e.clientY - position.y;
     const element = e.currentTarget as HTMLElement;
 
+    let didBreakSnap = false;
+
     const handleDragMove = (e: PointerEvent) => {
       element.style.cursor = "grabbing";
+
+      const deltaX = e.clientX - startX - position.x;
+      const deltaY = e.clientY - startY - position.y;
+      const distance = Math.sqrt(deltaX ** 2 + deltaY ** 2);
+
+      // ✅ 일정 거리 이상 이동하면 snap 해제 + 이전 상태 복원
+      if (isSnapped && !didBreakSnap && distance > DRAG_THRESHOLD) {
+        requestAnimationFrame(() => {
+          setSize(prevSize);
+          setIsSnapped(false);
+        });
+        didBreakSnap = true;
+        return; // 복원 후 즉시 return하여 아래 위치 계산 로직 방지
+      }
+      const currentWidth = isSnapped ? prevSize.width : size.width;
+      const currentHeight = isSnapped ? prevSize.height : size.height;
+
       const newX = Math.max(
         0,
-        Math.min(window.innerWidth - size.width - getSidebarWidth() - PADDING, e.clientX - startX),
+        Math.min(
+          window.innerWidth - currentWidth - getSidebarWidth() - PADDING,
+          e.clientX - startX,
+        ),
       );
       const newY = Math.max(
         0,
-        Math.min(window.innerHeight - size.height - PADDING, e.clientY - startY),
+        Math.min(window.innerHeight - currentHeight - PADDING, e.clientY - startY),
       );
       setPosition({ x: newX, y: newY });
+
+      const sidebarWidth = getSidebarActualWidth();
+      const newSnapTarget = computeSnapTarget(e.clientX, e.clientY, sidebarWidth);
+      if (newSnapTarget) {
+        const availableWidth = window.innerWidth - sidebarWidth;
+        const fullHeight = window.innerHeight - PADDING;
+        const style = getSnapStyle(newSnapTarget, availableWidth, fullHeight);
+        setTarget({ target: newSnapTarget, style });
+      } else {
+        requestAnimationFrame(() => {
+          reset();
+        });
+      }
     };
 
     const handleDragEnd = (e: PointerEvent) => {
@@ -146,6 +199,7 @@ export const usePage = ({ x, y }: Position) => {
       if (snapTarget) {
         applySnap(snapTarget, sidebarWidth, availableWidth, fullHeight);
       }
+      reset();
     };
 
     document.addEventListener("pointermove", handleDragMove);

--- a/client/src/features/page/hooks/usePage.ts
+++ b/client/src/features/page/hooks/usePage.ts
@@ -5,6 +5,7 @@ import { Position, Size, Direction } from "@src/types/page";
 import { useIsSidebarOpen } from "@stores/useSidebarStore";
 
 const PADDING = SPACING.MEDIUM * 2;
+const SNAP_THRESHOLD = 24; // 스냅을 위한 임계값
 
 // 만약 maximize 상태면, 화면이 커질때도 꽉 촤게 해줘야함.
 export const usePage = ({ x, y }: Position) => {
@@ -23,6 +24,93 @@ export const usePage = ({ x, y }: Position) => {
   const isSidebarOpen = useIsSidebarOpen();
 
   const getSidebarWidth = () => (isSidebarOpen ? SIDE_BAR.WIDTH : SIDE_BAR.MIN_WIDTH);
+
+  const getSidebarActualWidth = () => {
+    const sidebar = document.querySelector("[data-sidebar]") as HTMLElement | null;
+    return sidebar?.offsetWidth ?? 0;
+  };
+
+  const computeSnapTarget = (
+    x: number,
+    y: number,
+    sidebarWidth: number,
+  ): "topLeft" | "topRight" | "left" | "right" | "bottomLeft" | "bottomRight" | null => {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    // Y 영역 퍼센트 기반 구간
+    const topLimit = height * 0.05; // 상단 5%
+    const middleEnd = height * 0.5; // 중간 끝: 50%
+    const bottomStart = middleEnd; // 하단 시작
+
+    const isTop = y < topLimit;
+    const isMiddle = y >= topLimit && y < middleEnd;
+    const isBottom = y >= bottomStart;
+
+    // X 영역 좌우 끝 임계값
+    const isLeftEdge = x <= SNAP_THRESHOLD + sidebarWidth;
+    const isRightEdge = x >= width - SNAP_THRESHOLD;
+
+    if (isLeftEdge && isTop) return "topLeft";
+    if (isRightEdge && isTop) return "topRight";
+    if (isLeftEdge && isMiddle) return "left";
+    if (isRightEdge && isMiddle) return "right";
+    if (isLeftEdge && isBottom) return "bottomLeft";
+    if (isRightEdge && isBottom) return "bottomRight";
+
+    return null;
+  };
+
+  const applySnap = (
+    target: ReturnType<typeof computeSnapTarget>,
+    sidebarWidth: number,
+    availableWidth: number,
+    fullHeight: number,
+  ) => {
+    const halfWidth = availableWidth / 2;
+    const halfHeight = fullHeight / 2;
+    const leftX = 0;
+    const rightX = halfWidth - PADDING;
+
+    const base = {
+      width: halfWidth,
+      isMaximized: false,
+    };
+
+    const apply = (x: number, y: number, height: number) => {
+      setPrevPosition(position);
+      setPrevSize(size);
+      setPosition({ x, y });
+      setSize({ ...base, height });
+      setIsMaximized(false);
+    };
+
+    switch (target) {
+      case "left":
+        apply(leftX, 0, fullHeight);
+        break;
+
+      case "right":
+        apply(rightX, 0, fullHeight);
+        break;
+
+      case "topLeft":
+        apply(leftX, 0, halfHeight);
+        break;
+
+      case "topRight":
+        apply(rightX, 0, halfHeight);
+        break;
+
+      case "bottomLeft":
+        apply(leftX, halfHeight, halfHeight);
+        break;
+
+      case "bottomRight":
+        apply(rightX, halfHeight, halfHeight);
+        break;
+    }
+  };
 
   const pageDrag = (e: React.PointerEvent) => {
     e.preventDefault();
@@ -43,10 +131,21 @@ export const usePage = ({ x, y }: Position) => {
       setPosition({ x: newX, y: newY });
     };
 
-    const handleDragEnd = () => {
+    const handleDragEnd = (e: PointerEvent) => {
       element.style.cursor = "default";
+
       document.removeEventListener("pointermove", handleDragMove);
       document.removeEventListener("pointerup", handleDragEnd);
+
+      const sidebarWidth = getSidebarActualWidth();
+      const availableWidth = window.innerWidth - sidebarWidth;
+      const fullHeight = window.innerHeight - PADDING;
+
+      const snapTarget = computeSnapTarget(e.clientX, e.clientY, sidebarWidth);
+
+      if (snapTarget) {
+        applySnap(snapTarget, sidebarWidth, availableWidth, fullHeight);
+      }
     };
 
     document.addEventListener("pointermove", handleDragMove);

--- a/client/src/features/page/hooks/usePage.ts
+++ b/client/src/features/page/hooks/usePage.ts
@@ -28,8 +28,10 @@ export const usePage = ({ x, y }: Position) => {
     e.preventDefault();
     const startX = e.clientX - position.x;
     const startY = e.clientY - position.y;
+    const element = e.currentTarget as HTMLElement;
 
     const handleDragMove = (e: PointerEvent) => {
+      element.style.cursor = "grabbing";
       const newX = Math.max(
         0,
         Math.min(window.innerWidth - size.width - getSidebarWidth() - PADDING, e.clientX - startX),
@@ -42,6 +44,7 @@ export const usePage = ({ x, y }: Position) => {
     };
 
     const handleDragEnd = () => {
+      element.style.cursor = "default";
       document.removeEventListener("pointermove", handleDragMove);
       document.removeEventListener("pointerup", handleDragEnd);
     };

--- a/client/src/features/page/hooks/usePage.ts
+++ b/client/src/features/page/hooks/usePage.ts
@@ -460,6 +460,23 @@ export const usePage = ({ x, y }: Position) => {
     };
   }, [position, size, isSidebarOpen]);
 
+  useEffect(() => {
+    if (!isSnapped) return;
+
+    const sidebarWidth = getSidebarWidth();
+    const availableWidth = window.innerWidth - sidebarWidth;
+
+    const isSnappedRight = position.x !== 0;
+
+    const adjustedWidth = availableWidth / 2 - PADDING * 0.75;
+
+    setSize((prev) => ({ ...prev, width: adjustedWidth }));
+    if (isSnappedRight) {
+      const rightX = adjustedWidth + PADDING * 0.5;
+      setPosition((prev) => ({ ...prev, x: rightX }));
+    }
+  }, [isSidebarOpen]);
+
   return {
     position,
     size,

--- a/client/src/features/page/hooks/usePage.ts
+++ b/client/src/features/page/hooks/usePage.ts
@@ -63,7 +63,7 @@ export const usePage = ({ x, y }: Position) => {
 
   const applySnap = (
     target: ReturnType<typeof computeSnapTarget>,
-    sidebarWidth: number,
+    _sidebarWidth: number,
     availableWidth: number,
     fullHeight: number,
   ) => {

--- a/client/src/features/workSpace/WorkSpace.tsx
+++ b/client/src/features/workSpace/WorkSpace.tsx
@@ -7,10 +7,13 @@ import { Sidebar } from "@components/sidebar/Sidebar";
 import { AIButton } from "@features/ai/AIButton";
 import { Page } from "@features/page/Page";
 import { ToastContainer } from "@src/components/Toast/ToastContainer";
+import { useSnapTargetStore } from "@src/stores/useSnapStore";
 import { useSocketStore } from "@src/stores/useSocketStore";
+import { SnapTarget } from "@src/types/page";
 import { workSpaceContainer, content } from "./WorkSpace.style";
 import { IntroScreen } from "./components/IntroScreen";
 import { OnboardingOverlay } from "./components/OnboardingOverlay";
+import { SnapOverlay } from "./components/SnapOverlay";
 import { usePagesManage } from "./hooks/usePagesManage";
 import { useWorkspaceInit } from "./hooks/useWorkspaceInit";
 
@@ -18,18 +21,19 @@ export const WorkSpace = () => {
   const [workspace, setWorkspace] = useState<WorkSpaceClass | null>(null);
   const { isLoading, isInitialized, error } = useWorkspaceInit();
   const { workspace: workspaceMetadata, clientId } = useSocketStore();
+  const activeTarget = useSnapTargetStore((state) => state.current);
   const [showOnboarding, setShowOnboarding] = useState(false);
+  const snapTargets: SnapTarget[] = [
+    "left",
+    "right",
+    "topLeft",
+    "topRight",
+    "bottomLeft",
+    "bottomRight",
+  ];
 
-  const {
-    pages,
-    fetchPage,
-    selectPage,
-    closePage,
-    updatePage,
-    initPages,
-    // initPagePosition,
-    openPage,
-  } = usePagesManage(workspace, clientId);
+  const { pages, fetchPage, selectPage, closePage, updatePage, initPages, openPage } =
+    usePagesManage(workspace, clientId);
   const visiblePages = pages.filter((page) => page.isVisible && page.isLoaded);
 
   useEffect(() => {
@@ -82,6 +86,13 @@ export const WorkSpace = () => {
           handlePageUpdate={updatePage}
         />
         <div className={content}>
+          {activeTarget && (
+            <SnapOverlay
+              activeTarget={activeTarget.target}
+              activeStyle={activeTarget.style}
+              snapTargets={snapTargets}
+            />
+          )}
           {visiblePages.map((page, idx) => (
             <Page
               key={page.id}

--- a/client/src/features/workSpace/components/OnboardingOverlay.tsx
+++ b/client/src/features/workSpace/components/OnboardingOverlay.tsx
@@ -68,7 +68,7 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
     },
   ];
   useEffect(() => {
-    const hasCompletedOnboarding = sessionStorage.getItem("hasCompletedOnboarding");
+    const hasCompletedOnboarding = localStorage.getItem("hasCompletedOnboarding");
     if (isShow && hasCompletedOnboarding === null) {
       // 요소들이 렌더링될 시간을 주기 위해 약간의 딜레이 추가
       const timer = setTimeout(() => {
@@ -94,7 +94,7 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
       setCurrentStep((prev) => prev + 1);
     } else {
       setIsVisible(false);
-      sessionStorage.setItem("hasCompletedOnboarding", "true");
+      localStorage.setItem("hasCompletedOnboarding", "true");
     }
   };
   const handleEnter = (e: React.KeyboardEvent<HTMLDivElement>) => {
@@ -109,7 +109,7 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
   };
   const handleOverlayClose = () => {
     setIsVisible(false);
-    sessionStorage.setItem("hasCompletedOnboarding", "true");
+    localStorage.setItem("hasCompletedOnboarding", "true");
   };
   const getTargetPosition = (selector: string) => {
     const element = document.querySelector(selector);

--- a/client/src/features/workSpace/components/OnboardingOverlay.tsx
+++ b/client/src/features/workSpace/components/OnboardingOverlay.tsx
@@ -100,6 +100,9 @@ export const OnboardingOverlay = ({ isShow }: OnboardingOverlayProps) => {
   const handleEnter = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Enter") {
       handleClose();
+    } else if (e.key === "Escape") {
+      setIsVisible(false);
+      localStorage.setItem("hasCompletedOnboarding", "true");
     }
   };
   const handlePrevious = () => {

--- a/client/src/features/workSpace/components/SnapOverlay.style.ts
+++ b/client/src/features/workSpace/components/SnapOverlay.style.ts
@@ -1,0 +1,34 @@
+import { css, cva } from "@styled-system/css";
+
+export const snapSkeleton = css({
+  zIndex: 9999,
+  position: "absolute",
+  top: 0,
+  left: 0,
+  width: "100vw",
+  height: "100vh",
+  pointerEvents: "none",
+});
+
+export const snapBox = cva({
+  base: {
+    position: "absolute",
+    borderRadius: "md",
+    margin: "md",
+    opacity: 0,
+    transition: "all 0.2s ease-in-out",
+    pointerEvents: "none",
+  },
+  variants: {
+    isActive: {
+      true: {
+        opacity: 0.5,
+        backgroundColor: "gray.300",
+      },
+      false: {
+        border: "none",
+        opacity: 0,
+      },
+    },
+  },
+});

--- a/client/src/features/workSpace/components/SnapOverlay.style.ts
+++ b/client/src/features/workSpace/components/SnapOverlay.style.ts
@@ -24,7 +24,7 @@ export const snapBox = cva({
     isActive: {
       true: {
         opacity: 0.5,
-        backgroundColor: "gray.300",
+        backgroundColor: "gray.100",
       },
       false: {
         border: "none",

--- a/client/src/features/workSpace/components/SnapOverlay.style.ts
+++ b/client/src/features/workSpace/components/SnapOverlay.style.ts
@@ -13,6 +13,7 @@ export const snapSkeleton = css({
 export const snapBox = cva({
   base: {
     position: "absolute",
+    border: "4px solid #004585",
     borderRadius: "md",
     margin: "md",
     opacity: 0,

--- a/client/src/features/workSpace/components/SnapOverlay.tsx
+++ b/client/src/features/workSpace/components/SnapOverlay.tsx
@@ -1,0 +1,24 @@
+import { SnapTarget } from "@src/types/page";
+import { snapSkeleton, snapBox } from "./SnapOverlay.style";
+
+export const SnapOverlay = ({
+  activeTarget,
+  activeStyle,
+  snapTargets,
+}: {
+  activeTarget: SnapTarget;
+  activeStyle: React.CSSProperties;
+  snapTargets: SnapTarget[];
+}) => {
+  return (
+    <div className={snapSkeleton}>
+      {snapTargets.map((target) => (
+        <div
+          key={target}
+          className={snapBox({ isActive: activeTarget === target })}
+          style={activeStyle}
+        />
+      ))}
+    </div>
+  );
+};

--- a/client/src/features/workSpace/hooks/useWorkspaceInit.ts
+++ b/client/src/features/workSpace/hooks/useWorkspaceInit.ts
@@ -13,7 +13,7 @@ export const useWorkspaceInit = (): UseWorkspaceInitReturn => {
   const [error, setError] = useState<Error | null>(null);
   const { socket } = useSocketStore();
 
-  const isFirstVisit = !sessionStorage.getItem("hasVisitedBefore");
+  const isFirstVisit = !localStorage.getItem("hasVisitedBefore");
 
   useEffect(() => {
     const initializeWorkspace = async () => {
@@ -23,9 +23,9 @@ export const useWorkspaceInit = (): UseWorkspaceInitReturn => {
 
         await new Promise((resolve) => setTimeout(resolve, IntroWaitTime));
 
-        // 첫 방문 표시 저장 (sessionStorage 사용)
+        // 첫 방문 표시 저장 (localStorage 사용)
         if (isFirstVisit) {
-          sessionStorage.setItem("hasVisitedBefore", "true");
+          localStorage.setItem("hasVisitedBefore", "true");
         }
         setIsInitialized(true);
       } catch (err) {

--- a/client/src/stores/useSnapStore.ts
+++ b/client/src/stores/useSnapStore.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+import { SnapTarget } from "@src/types/page";
+
+export interface SnapTargetInfo {
+  target: SnapTarget;
+  style: React.CSSProperties;
+}
+
+interface SnapTargetState {
+  current: SnapTargetInfo | null;
+  setTarget: (info: SnapTargetInfo) => void;
+  reset: () => void;
+}
+
+export const useSnapTargetStore = create<SnapTargetState>((set) => ({
+  current: null,
+  setTarget: (info) => set({ current: info }),
+  reset: () => set({ current: null }),
+}));

--- a/client/src/stores/useSocketStore.ts
+++ b/client/src/stores/useSocketStore.ts
@@ -203,7 +203,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
     if (socket) {
       socket.removeAllListeners();
       socket.disconnect();
-      sessionStorage.removeItem("currentWorkspace"); // sessionStorage 삭제
+      localStorage.removeItem("currentWorkspace"); // localStorage 삭제
       set({ socket: null, workspace: null, clientId: 0 });
     }
   },
@@ -217,7 +217,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
       }
       socket.disconnect();
     }
-    sessionStorage.removeItem("currentWorkspace");
+    localStorage.removeItem("currentWorkspace");
     set({ workspace: null }); // 상태도 초기화
     init(userId, workspaceId);
   },
@@ -225,7 +225,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
   fetchWorkspaceData: () => get().workspace,
 
   setWorkspace: (workspace: WorkSpaceSerializedProps) => {
-    sessionStorage.setItem("currentWorkspace", JSON.stringify(workspace));
+    localStorage.setItem("currentWorkspace", JSON.stringify(workspace));
     set({ workspace });
   },
 

--- a/client/src/stores/useUserStore.ts
+++ b/client/src/stores/useUserStore.ts
@@ -26,7 +26,7 @@ export const useUserStore = create<UserStore>()(
           set(() => ({ id, name, accessToken })),
         removeUserInfo: () => {
           set(() => ({ id: null, name: null, accessToken: null }));
-          sessionStorage.removeItem("nocta-storage");
+          localStorage.removeItem("nocta-storage");
         },
         getUserInfo: () => {
           const state = get();
@@ -45,7 +45,7 @@ export const useUserStore = create<UserStore>()(
     }),
     {
       name: "nocta-storage",
-      storage: createJSONStorage(() => sessionStorage),
+      storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         id: state.id,
         name: state.name,

--- a/client/src/types/page.ts
+++ b/client/src/types/page.ts
@@ -35,3 +35,5 @@ export const DIRECTIONS = [
 ] as const;
 
 export type Direction = (typeof DIRECTIONS)[number];
+
+export type SnapTarget = "left" | "right" | "topLeft" | "topRight" | "bottomLeft" | "bottomRight";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@pandabox/panda-plugins':
         specifier: ^0.0.8
         version: 0.0.8
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.60.5
         version: 5.60.5(react@18.3.1)
@@ -857,6 +860,21 @@ packages:
     resolution: {integrity: sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.6.9':
+    resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
+
+  '@floating-ui/dom@1.6.13':
+    resolution: {integrity: sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==}
+
+  '@floating-ui/react-dom@2.1.2':
+    resolution: {integrity: sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1280,6 +1298,215 @@ packages:
     resolution: {integrity: sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/primitive@1.1.2':
+    resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/react-arrow@1.1.4':
+    resolution: {integrity: sha512-qz+fxrqgNxG0dYew5l7qR3c7wdgRu1XVUHGnGYX7rg5HM4p9SWaRmJwfgR3J0SgyUKayLmzQIun+N6rWRgiRKw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.7':
+    resolution: {integrity: sha512-j5+WBUdhccJsmH5/H0K6RncjDtoALSEr6jbkaZu+bjw6hOPOhHycr6vEUujl+HBK8kjUfWcoCJXxP6e4lUlMZw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.4':
+    resolution: {integrity: sha512-3p2Rgm/a1cK0r/UVkx5F/K9v/EplfjAeIFCGOPYPO4lZ0jtg4iSQXt/YGTSLWaf4x7NG6Z4+uKFcylcTZjeqDA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.6':
+    resolution: {integrity: sha512-XmsIl2z1n/TsYFLIdYam2rmFwf9OC/Sh2avkbmVMDuBZIe7hSpM0cYnWPAo7nHOVx8zTuwDZGByfcqLdnzp3Vw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.4':
+    resolution: {integrity: sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.0':
+    resolution: {integrity: sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.0':
+    resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.4':
+    resolution: {integrity: sha512-DyW8VVeeMSSLFvAmnVnCwvI3H+1tpJFHT50r+tdOoMse9XqYDBCcyux8u3G2y+LOpt7fPQ6KKH0mhs+ce1+Z5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.0':
+    resolution: {integrity: sha512-rQj0aAWOpCdCMRbI6pLQm8r7S2BM3YhTa0SzOYD55k+hJA8oo9J+H+9wLM9oMlZWOX/wJWPTzfDfmZkf7LvCfg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rollup/pluginutils@5.1.3':
     resolution: {integrity: sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==}
@@ -5644,6 +5871,23 @@ snapshots:
 
   '@eslint/js@9.14.0': {}
 
+  '@floating-ui/core@1.6.9':
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/dom@1.6.13':
+    dependencies:
+      '@floating-ui/core': 1.6.9
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/react-dom@2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.6.13
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/utils@0.2.9': {}
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -6396,6 +6640,182 @@ snapshots:
   '@playwright/test@1.49.1':
     dependencies:
       playwright: 1.49.1
+
+  '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/react-arrow@1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-context@1.1.2(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-dismissable-layer@1.1.7(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-id@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-popper@1.2.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-portal@1.1.6(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-presence@1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-primitive@2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.0(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-slot@1.2.0(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-tooltip@1.2.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.7(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.6(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.0(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.12)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.12
+
+  '@radix-ui/react-visually-hidden@1.2.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rollup/pluginutils@5.1.3(rollup@4.24.3)':
     dependencies:


### PR DESCRIPTION
## 📝 변경 사항

- 페이지 드래그해서 가장자리로 이동하면 화면 분할하는 기능 추가(Snap)
- 온보딩 오버레이에서 Esc 입력하면 종료하도록 구현
- 드래그 커서 잡는 손모양으로 변경
- 스냅 오버레이 컴포넌트 구현
- 바텀 내비게이터 UX 및 툴팁기능 추가

## 🔍 변경 사항 설명
### Snap기능
- 맥이나 윈도우에서 지원하는 가장자리로 드래그해서 분할하는 기능을 추가했습니다.
- 현재 드래그했을 때 해당 위치 또는 크기를 보여주는 헬퍼 UI가 없어서 이게 제대로 된건지 아닌지 구별하지는 못하는 상태입니다.
- Threshold값을 임의로 지정했고, 좀더 사용해보면서 최적의 값으로 변경할 예정입니다.
- 현재 `좌측상단`, `좌측중앙`, `좌측하단`, `우측상단`, `우측중앙`, `우측하단` 이렇게 6가지 방향을 지원하고, 중앙상단 및 중앙 하단도 추가할 예정입니다.

### 온보딩 Esc 지원
- 온보딩중에 엔터를 클릭하면 다음으로 이동하는 기능만 있고 바로 종료하기 위해서는 마우스로 X버튼을 클릭해야 했습니다.
- 키입력 만으로 바로 종료할 수 있도록 Esc를 클릭하면 바로 종료할 수 있도록 구현했습니다.

### 페이지 드래그시 커서 스타일
- 현재 드래그할 때 커서가 십자가 화살표 모양이고, 드래그한 상태로 가장자리로 이동하면 해당 방향의 화살표로 계속 커서가 변하는 문제가 있었습니다.
- 드래그 중에는 어디로 이동하던 커서의 스타일을`grabbing`으로 통일해서 현재 드래그 중이다 라는 인터렉션을 주도록 수정했습니다.
- 브라우저 기본 지원 스타일중 그나마 괜찮아 보이는 것으로 정했습니다. 그래도 좀 맘에 안들어서 나중에 커스텀 스타일 지정할 수 있다면 변경할 예정입니다.

### 스냅 오버레이 구현(현훈님 피드백 반영)
- 드래그해서 사이드로 마우스를 이동시킬 경우, 맥이나 윈도우처럼 해당 위치에 오버레이 컴포넌트를 렌더링 하도록 구현했습니다.
- 스냅해서 크기를 변경한 페이지를 다시 드래그할 경우, 이전 크기로 복원됩니다.
- 각 섹션 사이에 약간의 마진을 둬서 디자인적으로 깔끔하게 수정했습니다.
- 사이드바 토글 시, 스냅된 페이지의 레이아웃을 유지하도록 구현했습니다.

### 바텀 내비게이션 UX 개선
- 기존에는 페이지가 커져 바텀 내비게이터를 가릴 경우, 바텀 내비게이터를 사용할 수 없어 UX적으로 문제가 있었습니다. 이를 해결하기 위해 바텀 내비게이터에 마우스를 올리면 페이지 위로 올라와 페이지가 가린 상태에서도 사용할 수 있도록 수정했습니다.
- 바텀 내비게이터 내부 버튼들에 마우스를 올리면 툴팁 컴포넌트를 통해 페이지 제목을 보여줄 수 있도록 수정했습니다(radix-ui/react-tooltip 활용)

## 🙏 질문 사항

- 현재 Y축 기준 위에서 10%가 상단 절반, 10%에서 90%가 절반 전체, 아래로 하단 90%를 차지하도록 설정했는데 사용해보시고 더 좋은 분할값이 있으면 말씀해주세요!
- 스냅 오버레이에 디자인을 임의로 작성했는데, 더 좋은 디자인 있으면 말씀해주세요. 적용하겠습니다!

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/5425371d-86e4-4d5d-87a4-53e93b643742

https://github.com/user-attachments/assets/c7f6967a-248e-456a-a170-59a3da1cf4e7

https://github.com/user-attachments/assets/766af8e6-c138-4771-ab38-070e68a4065b

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [x] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
