### PR TITLE
Refactor/useMarkdownGrammer 훅 모듈화

### DIFF
--- a/client/src/features/editor/Editor.tsx
+++ b/client/src/features/editor/Editor.tsx
@@ -10,6 +10,7 @@ import { useSocketStore } from "@src/stores/useSocketStore.ts";
 import { setCaretPosition, getAbsoluteCaretPosition } from "@src/utils/caretUtils.ts";
 import { editorContainer, addNewBlockButton } from "./Editor.style";
 import { Block } from "./components/block/Block";
+import { useMarkdownGrammer2 } from "./hooks/markdowngrammer/index.ts";
 import { useBlockDragAndDrop } from "./hooks/useBlockDragAndDrop";
 import { useBlockOperation } from "./hooks/useBlockOperation.ts";
 import { useBlockOptionSelect } from "./hooks/useBlockOption";
@@ -101,9 +102,20 @@ export const Editor = memo(({ testKey, pageId, serializedEditorData }: EditorPro
       sendCharInsertOperation,
     });
 
-  const { handleKeyDown: onKeyDown, handleInput: handleHrInput } = useMarkdownGrammer({
+  // const { handleKeyDown: onKeyDown, handleInput: handleHrInput } = useMarkdownGrammer({
+  //   editorCRDT: editorCRDT.current,
+  //   editorState,
+  //   setEditorState,
+  //   pageId,
+  //   clientId,
+  //   sendBlockInsertOperation,
+  //   sendBlockDeleteOperation,
+  //   sendBlockUpdateOperation,
+  //   sendCharDeleteOperation,
+  //   sendCharInsertOperation,
+  // });
+  const { handleKeyDown: onKeyDown, handleInput: handleHrInput } = useMarkdownGrammer2({
     editorCRDT: editorCRDT.current,
-    editorState,
     setEditorState,
     pageId,
     clientId,

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/arrow.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/arrow.ts
@@ -1,0 +1,135 @@
+import { getAbsoluteCaretPosition, setCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+import { findBlockByIndex, isEditableBlock } from "../utils";
+
+export const handleArrowKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  const { editorCRDT, pageId } = ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock || e.nativeEvent.isComposing) return;
+
+  const currentIndex = editorCRDT.LinkedList.spread().findIndex((block) =>
+    block.id.equals(currentBlock.id),
+  );
+
+  const caretPosition = getAbsoluteCaretPosition(e.currentTarget);
+  const textLength = currentBlock.crdt.read().length;
+
+  const moveToBlock = (targetBlockIndex: number, caretPos: number) => {
+    const targetBlock = findBlockByIndex(editorCRDT, targetBlockIndex);
+    if (targetBlock && isEditableBlock(targetBlock)) {
+      targetBlock.crdt.currentCaret = Math.min(caretPos, targetBlock.crdt.read().length);
+      editorCRDT.currentBlock = targetBlock;
+      setCaretPosition({
+        blockId: targetBlock.id,
+        position: targetBlock.crdt.currentCaret,
+        pageId,
+      });
+    }
+  };
+
+  switch (e.key) {
+    case "ArrowUp": {
+      const hasPrev = currentIndex > 0;
+      if (!hasPrev) {
+        e.preventDefault();
+        return;
+      }
+
+      let targetIndex = currentIndex - 1;
+      let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+      while (targetBlock && targetBlock.type === "hr") {
+        targetIndex -= 1;
+        targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+      }
+
+      if (!targetBlock || targetBlock.type === "hr") return;
+
+      e.preventDefault();
+      moveToBlock(targetIndex, caretPosition);
+      break;
+    }
+
+    case "ArrowDown": {
+      const hasNext = currentIndex < editorCRDT.LinkedList.spread().length - 1;
+      if (!hasNext) {
+        e.preventDefault();
+        return;
+      }
+
+      let targetIndex = currentIndex + 1;
+      let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+      while (targetBlock && targetBlock.type === "hr") {
+        targetIndex += 1;
+        targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+      }
+
+      if (!targetBlock || targetBlock.type === "hr") return;
+
+      e.preventDefault();
+      moveToBlock(targetIndex, caretPosition);
+      break;
+    }
+
+    case "ArrowLeft": {
+      if (caretPosition === 0 && currentIndex > 0) {
+        e.preventDefault();
+
+        let targetIndex = currentIndex - 1;
+        let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+        while (targetBlock && targetBlock.type === "hr") {
+          targetIndex -= 1;
+          targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+        }
+
+        if (targetBlock && targetBlock.type !== "hr") {
+          targetBlock.crdt.currentCaret = targetBlock.crdt.read().length;
+          editorCRDT.currentBlock = targetBlock;
+          setCaretPosition({
+            blockId: targetBlock.id,
+            position: targetBlock.crdt.read().length,
+            pageId,
+          });
+        }
+        break;
+      } else {
+        currentBlock.crdt.currentCaret = Math.max(0, caretPosition - 1);
+      }
+      break;
+    }
+
+    case "ArrowRight": {
+      if (
+        caretPosition === textLength &&
+        currentIndex < editorCRDT.LinkedList.spread().length - 1
+      ) {
+        e.preventDefault();
+
+        let targetIndex = currentIndex + 1;
+        let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+        while (targetBlock && targetBlock.type === "hr") {
+          targetIndex += 1;
+          targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+        }
+
+        if (targetBlock && targetBlock.type !== "hr") {
+          targetBlock.crdt.currentCaret = 0;
+          editorCRDT.currentBlock = targetBlock;
+          setCaretPosition({
+            blockId: targetBlock.id,
+            position: 0,
+            pageId,
+          });
+        }
+        break;
+      } else {
+        currentBlock.crdt.currentCaret = Math.min(textLength, caretPosition + 1);
+      }
+      break;
+    }
+  }
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/backspace.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/backspace.ts
@@ -1,0 +1,171 @@
+import { setCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+import { updateEditorState, decreaseIndent, findBlockByIndex } from "../utils";
+
+export const handleBackspaceKey = (
+  e: React.KeyboardEvent<HTMLDivElement>,
+  ctx: KeyHandlerContext,
+) => {
+  const {
+    editorCRDT,
+    pageId,
+    clientId,
+    setEditorState,
+    sendBlockDeleteOperation,
+    sendBlockUpdateOperation,
+    sendCharInsertOperation,
+    sendCharDeleteOperation,
+  } = ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  const currentContent = currentBlock.crdt.read();
+  const currentCharNodes = currentBlock.crdt.spread();
+  const currentIndex = editorCRDT.LinkedList.spread().findIndex((block) =>
+    block.id.equals(currentBlock.id),
+  );
+
+  const update = () => updateEditorState(editorCRDT, setEditorState);
+
+  if (currentContent === "") {
+    e.preventDefault();
+
+    if (currentBlock.indent > 0) {
+      decreaseIndent(editorCRDT, currentBlock, pageId, setEditorState, sendBlockUpdateOperation);
+      return;
+    }
+
+    if (currentBlock.type === "p") {
+      const prevBlock = currentBlock.prev ? editorCRDT.LinkedList.getNode(currentBlock.prev) : null;
+      const nextBlock = currentBlock.next ? editorCRDT.LinkedList.getNode(currentBlock.next) : null;
+
+      if (prevBlock?.type === "ol" && nextBlock?.type === "ol") {
+        sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
+        editorCRDT.LinkedList.updateAllOrderedListIndices();
+
+        editorCRDT.currentBlock = prevBlock;
+        prevBlock.crdt.currentCaret = prevBlock.crdt.read().length;
+        update();
+        return;
+      }
+    }
+
+    if (currentBlock.type !== "p") {
+      const wasOrderedList = currentBlock.type === "ol";
+      currentBlock.type = "p";
+      sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+      editorCRDT.currentBlock = currentBlock;
+
+      if (wasOrderedList) {
+        editorCRDT.LinkedList.updateAllOrderedListIndices();
+      }
+      update();
+      return;
+    }
+
+    const prevBlock = currentIndex > 0 ? editorCRDT.LinkedList.findByIndex(currentIndex - 1) : null;
+
+    if (prevBlock) {
+      sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
+
+      let targetIndex = currentIndex - 1;
+      let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+      while (targetBlock && targetBlock.type === "hr") {
+        targetIndex -= 1;
+        targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+      }
+
+      if (targetBlock && targetBlock.type !== "hr") {
+        targetBlock.crdt.currentCaret = targetBlock.crdt.read().length;
+        editorCRDT.currentBlock = targetBlock;
+        setCaretPosition({
+          blockId: targetBlock.id,
+          position: targetBlock.crdt.read().length,
+          pageId,
+        });
+      }
+
+      update();
+    }
+
+    return;
+  }
+
+  const { currentCaret } = currentBlock.crdt;
+  if (currentCaret === 0) {
+    if (currentBlock.indent > 0) {
+      decreaseIndent(editorCRDT, currentBlock, pageId, setEditorState, sendBlockUpdateOperation);
+      update();
+      return;
+    }
+
+    if (currentBlock.type !== "p") {
+      const wasOrderedList = currentBlock.type === "ol";
+      currentBlock.type = "p";
+      sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+      editorCRDT.currentBlock = currentBlock;
+      if (wasOrderedList) {
+        editorCRDT.LinkedList.updateAllOrderedListIndices();
+      }
+      update();
+      return;
+    }
+
+    const prevBlock = currentIndex > 0 ? editorCRDT.LinkedList.findByIndex(currentIndex - 1) : null;
+    const nextBlock =
+      currentIndex < editorCRDT.LinkedList.spread().length - 1
+        ? editorCRDT.LinkedList.findByIndex(currentIndex + 1)
+        : null;
+
+    if (prevBlock) {
+      let targetIndex = currentIndex - 1;
+      let targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+
+      while (targetBlock && targetBlock.type === "hr") {
+        targetIndex -= 1;
+        targetBlock = findBlockByIndex(editorCRDT, targetIndex);
+      }
+
+      if (targetBlock && prevBlock.type === "hr") {
+        editorCRDT.currentBlock = targetBlock;
+        editorCRDT.currentBlock.crdt.currentCaret = targetBlock.crdt.read().length;
+        update();
+        return;
+      }
+
+      const prevBlockEndCaret = prevBlock.crdt.read().length;
+
+      for (let i = 0; i < currentContent.length; i++) {
+        const currentCharNode = currentCharNodes[i];
+        sendCharInsertOperation(
+          prevBlock.crdt.localInsert(
+            prevBlockEndCaret + i,
+            currentContent[i],
+            prevBlock.id,
+            pageId,
+            clientId,
+            currentCharNode.style,
+            currentCharNode.color,
+            currentCharNode.backgroundColor,
+          ),
+        );
+      }
+
+      currentContent.split("").forEach(() => {
+        sendCharDeleteOperation(currentBlock.crdt.localDelete(0, currentBlock.id, pageId));
+      });
+
+      editorCRDT.currentBlock = prevBlock;
+      prevBlock.crdt.currentCaret = prevBlockEndCaret;
+      sendBlockDeleteOperation(editorCRDT.localDelete(currentIndex, undefined, pageId));
+      update();
+
+      if (prevBlock.type === "ol" && nextBlock?.type === "ol") {
+        editorCRDT.LinkedList.updateAllOrderedListIndices();
+      }
+      e.preventDefault();
+    }
+  }
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/delete.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/delete.ts
@@ -1,0 +1,27 @@
+import { KeyHandlerContext } from "../types";
+import { updateEditorState } from "../utils";
+
+export const handleDeleteKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  if (e.nativeEvent.isComposing) return;
+  const { editorCRDT, pageId, sendCharDeleteOperation, setEditorState } = ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  const currentContent = currentBlock.crdt.read();
+
+  if (!currentBlock.next || currentContent) return;
+
+  const nextBlock = editorCRDT.LinkedList.getNode(currentBlock.next);
+  if (!nextBlock) return;
+
+  sendCharDeleteOperation(
+    currentBlock.crdt.localDelete(
+      editorCRDT.LinkedList.spread().findIndex((b) => b.id.equals(currentBlock.id)) + 1,
+      currentBlock.id,
+      pageId,
+    ),
+  );
+
+  updateEditorState(editorCRDT, setEditorState);
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/enter.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/enter.ts
@@ -1,0 +1,103 @@
+import { BlockCRDT } from "@noctaCrdt/Crdt";
+import { getAbsoluteCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+import { createNewBlock, updateEditorState } from "../utils";
+
+export const handleEnterKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  const {
+    editorCRDT,
+    pageId,
+    clientId,
+    setEditorState,
+    sendBlockInsertOperation,
+    sendBlockUpdateOperation,
+    sendCharInsertOperation,
+    sendCharDeleteOperation,
+  } = ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock || e.nativeEvent.isComposing) return;
+
+  e.preventDefault();
+
+  const caretPosition = getAbsoluteCaretPosition(e.currentTarget);
+  const currentContent = currentBlock.crdt.read();
+  const currentCharNodes = currentBlock.crdt.spread();
+  const currentIndex = editorCRDT.LinkedList.spread().findIndex((b) =>
+    b.id.equals(currentBlock.id),
+  );
+
+  if (!currentContent && currentBlock.type !== "p") {
+    const wasOrderedList = currentBlock.type === "ol";
+    currentBlock.type = "p";
+    sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+    editorCRDT.currentBlock = currentBlock;
+    currentBlock.crdt.currentCaret = 0;
+    if (wasOrderedList) {
+      editorCRDT.LinkedList.updateAllOrderedListIndices();
+    }
+    updateEditorState(editorCRDT, setEditorState);
+    return;
+  }
+
+  if (!currentContent && currentBlock.type === "p") {
+    const operation = createNewBlock(editorCRDT, currentIndex + 1);
+    operation.node.indent = currentBlock.indent;
+    operation.node.crdt = new BlockCRDT(editorCRDT.client);
+
+    sendBlockInsertOperation({ type: "blockInsert", node: operation.node, pageId });
+    editorCRDT.currentBlock = operation.node;
+    editorCRDT.currentBlock.crdt.currentCaret = 0;
+    updateEditorState(editorCRDT, setEditorState);
+    return;
+  }
+
+  const afterContent = currentContent.slice(caretPosition);
+  const afterCharNodes = currentCharNodes.slice(caretPosition);
+
+  const operation = createNewBlock(editorCRDT, currentIndex + 1);
+  const newBlock = operation.node;
+  newBlock.indent = currentBlock.indent;
+
+  if (currentBlock.type === "ol") {
+    newBlock.listIndex = currentBlock.listIndex! + 1;
+  }
+
+  sendBlockInsertOperation({ type: "blockInsert", node: newBlock, pageId });
+
+  if (afterContent) {
+    afterContent.split("").forEach((char, i) => {
+      const charNode = afterCharNodes[i];
+      sendCharInsertOperation(
+        newBlock.crdt.localInsert(
+          i,
+          char,
+          newBlock.id,
+          pageId,
+          clientId,
+          charNode.style,
+          charNode.color,
+          charNode.backgroundColor,
+        ),
+      );
+    });
+
+    for (let i = currentContent.length - 1; i >= caretPosition; i--) {
+      sendCharDeleteOperation(currentBlock.crdt.localDelete(i, currentBlock.id, pageId));
+    }
+  }
+
+  if (["ul", "ol", "checkbox"].includes(currentBlock.type)) {
+    newBlock.type = currentBlock.type;
+    sendBlockUpdateOperation(editorCRDT.localUpdate(newBlock, pageId));
+  }
+
+  editorCRDT.currentBlock = newBlock;
+  newBlock.crdt.currentCaret = 0;
+
+  if (currentBlock.type === "ol") {
+    editorCRDT.LinkedList.updateAllOrderedListIndices();
+  }
+
+  updateEditorState(editorCRDT, setEditorState);
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/homeend.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/homeend.ts
@@ -1,0 +1,20 @@
+import { setCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+
+export const handleHomeEndKey = (
+  e: React.KeyboardEvent<HTMLDivElement>,
+  ctx: KeyHandlerContext,
+) => {
+  const { editorCRDT, pageId } = ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  currentBlock.crdt.currentCaret = e.key === "Home" ? 0 : currentBlock.crdt.read().length;
+
+  setCaretPosition({
+    blockId: currentBlock.id,
+    position: currentBlock.crdt.currentCaret,
+    pageId,
+  });
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/page.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/page.ts
@@ -1,0 +1,54 @@
+import { setCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+
+export const handlePageUpKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  const { editorCRDT, pageId } = ctx;
+
+  e.preventDefault();
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  const currentCaretPosition = currentBlock.crdt.currentCaret;
+  const headBlock = editorCRDT.LinkedList.getNode(editorCRDT.LinkedList.head);
+  if (!headBlock) return;
+
+  headBlock.crdt.currentCaret = Math.min(currentCaretPosition, headBlock.crdt.read().length);
+
+  editorCRDT.currentBlock = headBlock;
+
+  setCaretPosition({
+    blockId: headBlock.id,
+    position: currentCaretPosition,
+    pageId,
+  });
+};
+
+export const handlePageDownKey = (
+  e: React.KeyboardEvent<HTMLDivElement>,
+  ctx: KeyHandlerContext,
+) => {
+  const { editorCRDT, pageId } = ctx;
+
+  e.preventDefault();
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  const currentCaretPosition = currentBlock.crdt.currentCaret;
+  let lastBlock = currentBlock;
+
+  while (lastBlock.next && editorCRDT.LinkedList.getNode(lastBlock.next)) {
+    lastBlock = editorCRDT.LinkedList.getNode(lastBlock.next)!;
+  }
+
+  lastBlock.crdt.currentCaret = Math.min(currentCaretPosition, lastBlock.crdt.read().length);
+
+  editorCRDT.currentBlock = lastBlock;
+
+  setCaretPosition({
+    blockId: lastBlock.id,
+    position: currentCaretPosition,
+    pageId,
+  });
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/space.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/space.ts
@@ -1,0 +1,41 @@
+import { checkMarkdownPattern } from "@src/features/editor/utils/markdownPatterns";
+import { getAbsoluteCaretPosition } from "@src/utils/caretUtils";
+import { KeyHandlerContext } from "../types";
+import { updateEditorState } from "../utils";
+
+export const handleSpaceKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  const { editorCRDT, pageId, setEditorState, sendBlockUpdateOperation, sendCharDeleteOperation } =
+    ctx;
+
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock) return;
+
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  const currentContent = currentBlock.crdt.read();
+  const currentCaret = getAbsoluteCaretPosition(e.currentTarget);
+  const markdownElement = checkMarkdownPattern(currentContent);
+
+  if (markdownElement && currentCaret === markdownElement.length && currentBlock.type === "p") {
+    e.preventDefault();
+
+    // 마크다운 패턴 매칭 시 타입 변경하고 내용 비우기
+    currentBlock.type = markdownElement.type;
+
+    for (let i = 0; i < markdownElement.length; i++) {
+      const op = currentBlock.crdt.localDelete(0, currentBlock.id, pageId);
+      sendCharDeleteOperation(op);
+    }
+
+    sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+    currentBlock.crdt.currentCaret = 0;
+    editorCRDT.currentBlock = currentBlock;
+
+    if (markdownElement.type === "ol") {
+      editorCRDT.LinkedList.updateAllOrderedListIndices();
+    }
+
+    updateEditorState(editorCRDT, setEditorState);
+  }
+};

--- a/client/src/features/editor/hooks/markdowngrammer/handlers/tab.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/handlers/tab.ts
@@ -1,0 +1,42 @@
+import { KeyHandlerContext } from "../types";
+import { decreaseIndent, updateEditorState } from "../utils";
+
+export const handleTabKey = (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => {
+  const { editorCRDT, pageId, setEditorState, sendBlockUpdateOperation } = ctx;
+  const { currentBlock } = editorCRDT;
+  if (!currentBlock || e.nativeEvent.isComposing) return;
+
+  e.preventDefault();
+
+  if (currentBlock) {
+    if (e.shiftKey) {
+      // shift + tab: 들여쓰기 감소
+      if (currentBlock.indent > 0) {
+        decreaseIndent(editorCRDT, currentBlock, pageId, setEditorState, sendBlockUpdateOperation);
+        updateEditorState(editorCRDT, setEditorState);
+      }
+    } else {
+      if (!currentBlock.prev) return;
+
+      const parentIndent =
+        editorCRDT.LinkedList.nodeMap[JSON.stringify(currentBlock.prev)]?.indent ?? 0;
+
+      const maxIndent = Math.min(
+        parentIndent + 1, // 부모 indent + 1
+        2, // 들여쓰기 최대 indent
+      );
+
+      // 현재 indent가 허용된 최대값보다 작을 때만 들여쓰기 증가
+      if (currentBlock.indent < maxIndent) {
+        const isOrderedList = currentBlock.type === "ol";
+        currentBlock.indent += 1;
+        sendBlockUpdateOperation(editorCRDT.localUpdate(currentBlock, pageId));
+        editorCRDT.currentBlock = currentBlock;
+        if (isOrderedList) {
+          editorCRDT.LinkedList.updateAllOrderedListIndices();
+        }
+        updateEditorState(editorCRDT, setEditorState);
+      }
+    }
+  }
+};

--- a/client/src/features/editor/hooks/markdowngrammer/index.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/index.ts
@@ -1,0 +1,132 @@
+import { EditorCRDT } from "@noctaCrdt/Crdt";
+import { BlockLinkedList } from "@noctaCrdt/LinkedList";
+import { Block } from "@noctaCrdt/Node";
+import {
+  RemoteBlockInsertOperation,
+  RemoteBlockDeleteOperation,
+  RemoteCharDeleteOperation,
+  RemoteCharInsertOperation,
+  RemoteBlockUpdateOperation,
+} from "@noctaCrdt/types/Interfaces";
+import { useCallback } from "react";
+import { handleArrowKey } from "./handlers/arrow";
+import { handleBackspaceKey } from "./handlers/backspace";
+import { handleDeleteKey } from "./handlers/delete";
+import { handleEnterKey } from "./handlers/enter";
+import { handleHomeEndKey } from "./handlers/homeend";
+import { handlePageDownKey, handlePageUpKey } from "./handlers/page";
+import { handleSpaceKey } from "./handlers/space";
+import { handleTabKey } from "./handlers/tab";
+import { KeyHandlerContext } from "./types";
+
+interface useMarkdownGrammerProps {
+  editorCRDT: EditorCRDT;
+  setEditorState: React.Dispatch<
+    React.SetStateAction<{
+      clock: number;
+      linkedList: BlockLinkedList;
+    }>
+  >;
+  pageId: string;
+  clientId: number;
+  sendBlockInsertOperation: (operation: RemoteBlockInsertOperation) => void;
+  sendBlockDeleteOperation: (operation: RemoteBlockDeleteOperation) => void;
+  sendCharDeleteOperation: (operation: RemoteCharDeleteOperation) => void;
+  sendCharInsertOperation: (operation: RemoteCharInsertOperation) => void;
+  sendBlockUpdateOperation: (operation: RemoteBlockUpdateOperation) => void;
+}
+
+export const useMarkdownGrammer2 = ({
+  editorCRDT,
+  setEditorState,
+  pageId,
+  clientId,
+  sendBlockInsertOperation,
+  sendBlockDeleteOperation,
+  sendCharDeleteOperation,
+  sendCharInsertOperation,
+  sendBlockUpdateOperation,
+}: useMarkdownGrammerProps) => {
+  const ctx: KeyHandlerContext = {
+    editorCRDT,
+    setEditorState,
+    pageId,
+    clientId,
+    sendBlockInsertOperation,
+    sendBlockDeleteOperation,
+    sendCharDeleteOperation,
+    sendCharInsertOperation,
+    sendBlockUpdateOperation,
+  };
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const { key } = e;
+
+      // 키와 핸들러 매핑
+      const handlerMap: Record<
+        string,
+        (e: React.KeyboardEvent<HTMLDivElement>, ctx: KeyHandlerContext) => void
+      > = {
+        Enter: handleEnterKey,
+        Backspace: handleBackspaceKey,
+        Tab: handleTabKey,
+        Delete: handleDeleteKey,
+        Home: handleHomeEndKey,
+        End: handleHomeEndKey,
+        PageUp: handlePageUpKey,
+        PageDown: handlePageDownKey,
+        ArrowUp: handleArrowKey,
+        ArrowDown: handleArrowKey,
+        ArrowLeft: handleArrowKey,
+        ArrowRight: handleArrowKey,
+        " ": handleSpaceKey,
+      };
+
+      const handler = handlerMap[key];
+      if (handler) {
+        handler(e, ctx);
+      }
+    },
+    [ctx],
+  );
+
+  const handleInput = useCallback(
+    (block: Block, newContent: string) => {
+      if (newContent === "---") {
+        const currentContent = block.crdt.read();
+        currentContent.split("").forEach((_) => {
+          const operationNode = block.crdt.localDelete(0, block.id, pageId);
+          sendCharDeleteOperation(operationNode);
+        });
+
+        block.type = "hr";
+        sendBlockUpdateOperation(editorCRDT.localUpdate(block, pageId));
+
+        // 새로운 블록 생성
+        const currentIndex = editorCRDT.LinkedList.spread().findIndex((b) => b.id.equals(block.id));
+        const operation = editorCRDT.localInsert(currentIndex + 1, "");
+        operation.node.type = "p";
+        sendBlockInsertOperation({ type: "blockInsert", node: operation.node, pageId });
+
+        editorCRDT.currentBlock = operation.node;
+        editorCRDT.currentBlock.crdt.currentCaret = 0;
+
+        setEditorState({
+          clock: editorCRDT.clock,
+          linkedList: editorCRDT.LinkedList,
+        });
+
+        return true;
+      }
+      return false;
+    },
+    [
+      editorCRDT,
+      sendCharDeleteOperation,
+      sendBlockUpdateOperation,
+      sendBlockInsertOperation,
+      pageId,
+    ],
+  );
+  return { handleKeyDown, handleInput };
+};

--- a/client/src/features/editor/hooks/markdowngrammer/types.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/types.ts
@@ -1,0 +1,29 @@
+import { EditorCRDT } from "@noctaCrdt/Crdt";
+import { BlockLinkedList } from "@noctaCrdt/LinkedList";
+
+import {
+  RemoteBlockInsertOperation,
+  RemoteBlockDeleteOperation,
+  RemoteBlockUpdateOperation,
+  RemoteCharInsertOperation,
+  RemoteCharDeleteOperation,
+} from "@noctaCrdt/types/Interfaces";
+
+export type SetEditorState = React.Dispatch<
+  React.SetStateAction<{
+    clock: number;
+    linkedList: BlockLinkedList;
+  }>
+>;
+
+export interface KeyHandlerContext {
+  editorCRDT: EditorCRDT;
+  setEditorState: SetEditorState;
+  pageId: string;
+  clientId: number;
+  sendBlockInsertOperation: (op: RemoteBlockInsertOperation) => void;
+  sendBlockDeleteOperation: (op: RemoteBlockDeleteOperation) => void;
+  sendCharDeleteOperation: (op: RemoteCharDeleteOperation) => void;
+  sendCharInsertOperation: (op: RemoteCharInsertOperation) => void;
+  sendBlockUpdateOperation: (op: RemoteBlockUpdateOperation) => void;
+}

--- a/client/src/features/editor/hooks/markdowngrammer/utils/index.ts
+++ b/client/src/features/editor/hooks/markdowngrammer/utils/index.ts
@@ -1,0 +1,80 @@
+import { EditorCRDT } from "@noctaCrdt/Crdt";
+import { BlockLinkedList } from "@noctaCrdt/LinkedList";
+import { Block } from "@noctaCrdt/Node";
+import { RemoteBlockUpdateOperation } from "@noctaCrdt/types/Interfaces";
+
+type SetEditorState = React.Dispatch<
+  React.SetStateAction<{
+    clock: number;
+    linkedList: BlockLinkedList;
+  }>
+>;
+
+export const createNewBlock = (editorCRDT: EditorCRDT, index: number) => {
+  const operation = editorCRDT.localInsert(index, "");
+  operation.node.type = "p";
+  return operation;
+};
+
+export const updateEditorState = (editorCRDT: EditorCRDT, setEditorState: SetEditorState) => {
+  setEditorState({
+    clock: editorCRDT.clock,
+    linkedList: editorCRDT.LinkedList,
+  });
+};
+
+export const findBlockByIndex = (editorCRDT: EditorCRDT, index: number) => {
+  if (index < 0) return null;
+  if (index >= editorCRDT.LinkedList.spread().length) return null;
+
+  return editorCRDT.LinkedList.findByIndex(index);
+};
+
+export const decreaseIndent = (
+  editorCRDT: EditorCRDT,
+  block: Block,
+  pageId: string,
+  setEditorState: SetEditorState,
+  sendBlockUpdateOperation: (operation: RemoteBlockUpdateOperation) => void,
+) => {
+  if (block.indent === 0) return;
+
+  const currentIndex = editorCRDT.LinkedList.spread().findIndex((block) =>
+    block.id.equals(block.id),
+  );
+
+  // 현재 블록의 indent 감소
+  const wasOrderedList = block.type === "ol";
+  const originalIndent = block.indent;
+  const newIndent = originalIndent - 1;
+  block.indent = newIndent;
+  sendBlockUpdateOperation(editorCRDT.localUpdate(block, pageId));
+
+  // 자식 블록들 찾기 및 업데이트
+  const blocks = editorCRDT.LinkedList.spread();
+  let i = currentIndex + 1;
+
+  // 현재 블록의 원래 indent보다 큰 블록들만 처리 (자식 블록들만)
+  while (i < blocks.length && blocks[i].indent > originalIndent) {
+    const childBlock = blocks[i];
+
+    // 자식 블록의 indent도 1 감소
+    childBlock.indent = Math.max(0, childBlock.indent - 1);
+    sendBlockUpdateOperation(editorCRDT.localUpdate(childBlock, pageId));
+
+    i += 1;
+  }
+
+  // ordered list인 경우 인덱스 업데이트
+  if (wasOrderedList) {
+    editorCRDT.LinkedList.updateAllOrderedListIndices();
+  }
+
+  editorCRDT.currentBlock = block;
+  updateEditorState(editorCRDT, setEditorState);
+};
+
+export const isEditableBlock = (block: Block | null): boolean => {
+  if (!block) return false;
+  return block.type !== "hr";
+};


### PR DESCRIPTION
## 📝 변경 사항

- useMarkdownGrammer훅 내부 키입력별 핸들러 별도 모듈로 분리

## 🔍 변경 사항 설명

- 기존 handleKeyDown 내 모든 키 이벤트 처리 로직(Enter, Backspace, Tab, Arrow 등)을 각각 독립적인 handler 함수로 모듈화하였습니다.
- 각 handler는 기존 로직을 그대로 유지하며, 기능 변경 없이 코드 품질 개선 및 가독성 향상에 초점을 맞추었습니다.
- 중복되는 updateEditorState, decreaseIndent, findBlockByIndex 등 유틸성 로직도 별도 모듈로 추출하였습니다.
- handlerMap을 통한 key-handler 매핑으로 switch-case 제거 → 유지보수성 향상

## 🙏 질문 사항
# 테스트를 위한 PR입니다!
- approve는 최종 테스트 이후에 부탁드립니다.
- 핸들러별 로직 개선하기에는 건드리기가 너무 복잡해서 최대한 `기존 로직 및 코드 그대로` 분리하는 형식으로 리팩토링을 진행했습니다.
- 현재 개인적으로 최대한 많은 케이스를 테스트를 해보긴 했지만, 아직 확실하진 않습니다. 나중에 같이 테스트해보고 문제가 있는 부분이 있거나, 적용하는데 문제가 있다면, PR close할 예정입니다!

## 📷 스크린샷 (선택)

- UI 변경이 있는 경우 스크린샷이나 GIF를 첨부합니다.

## ✅ 작성자 체크리스트

- [x] Self-review: 코드가 스스로 검토됨
- [ ] Unit tests 추가 또는 수정
- [x] 로컬에서 모든 기능이 정상 작동함
- [x] 린터 및 포맷터로 코드 정리됨
- [ ] 의존성 업데이트 확인
- [ ] 문서 업데이트 또는 주석 추가 (필요 시)
